### PR TITLE
Add ThemeProvider to Navigation and Footer organisms

### DIFF
--- a/packages/UI/src/components/organisms/Footer/Footer.js
+++ b/packages/UI/src/components/organisms/Footer/Footer.js
@@ -1,4 +1,6 @@
 import Link from 'next/link';
+import {ThemeProvider} from 'styled-components';
+import theme from "../../../styles/theme";
 
 import Newsletter from './Newsletter';
 import RandomQuote from './RandomQuote';
@@ -15,60 +17,62 @@ import {
 export default function Footer() {
   return (
     <Wrapper>
-      <Newsletter />
-      <FooterNav>
-        <Link href={'/create'} passHref className="nav-link">
-          <a>
-            <NavEntry>CREATE</NavEntry>
-          </a>
-        </Link>
-        <Link href={'/learn'} passHref className="nav-link">
-          <a>
-            <NavEntry>LEARN</NavEntry>
-          </a>
-        </Link>
-        <Link href={'/ideas'} passHref className="nav-link">
-          <a>
-            <NavEntry>DREAM</NavEntry>
-          </a>
-        </Link>
-        {/* }
-        <Link href={"/play"} passHref className="nav-link">
-          <NavEntry>PLAY</NavEntry>
-        </Link>
-        { */}
-        <Link href={'/support-us'} passHref className="nav-link">
-          <a>
-            <NavEntry>SUPPORT US</NavEntry>
-          </a>
-        </Link>
-        <Link href={'/projects'} passHref className="nav-link">
-          <a>
-            <NavEntry>JOIN</NavEntry>
-          </a>
-        </Link>
-      </FooterNav>
-      <SocialMediaContainer>
-        <SocialMediaLink Type="Instagram" />
-        <Link href={'/'} passHref className="nav-link">
-          <a>
-            <FooterLogo />
-          </a>
-        </Link>
-        <SocialMediaLink Type="Linkedin" />
-      </SocialMediaContainer>
-      <RandomQuote />
-      <OrgInfoArea>
-        -
-        <Link href="/page/terms-and-conditions" passHref>
-          <a>Terms of Service </a>
-        </Link>
-        - | -
-        <Link href="/page/privacy-policy" passHref>
-          <a>Privacy Policy </a>
-        </Link>{' '}
-        {'- | '} ©Dev Launchers, 2021.
-      </OrgInfoArea>
+      <ThemeProvider theme={theme}>
+        <Newsletter />
+        <FooterNav>
+          <Link href={'/create'} passHref className="nav-link">
+            <a>
+              <NavEntry>CREATE</NavEntry>
+            </a>
+          </Link>
+          <Link href={'/learn'} passHref className="nav-link">
+            <a>
+              <NavEntry>LEARN</NavEntry>
+            </a>
+          </Link>
+          <Link href={'/ideas'} passHref className="nav-link">
+            <a>
+              <NavEntry>DREAM</NavEntry>
+            </a>
+          </Link>
+          {/* }
+          <Link href={"/play"} passHref className="nav-link">
+            <NavEntry>PLAY</NavEntry>
+          </Link>
+          { */}
+          <Link href={'/support-us'} passHref className="nav-link">
+            <a>
+              <NavEntry>SUPPORT US</NavEntry>
+            </a>
+          </Link>
+          <Link href={'/projects'} passHref className="nav-link">
+            <a>
+              <NavEntry>JOIN</NavEntry>
+            </a>
+          </Link>
+        </FooterNav>
+        <SocialMediaContainer>
+          <SocialMediaLink Type="Instagram" />
+          <Link href={'/'} passHref className="nav-link">
+            <a>
+              <FooterLogo />
+            </a>
+          </Link>
+          <SocialMediaLink Type="Linkedin" />
+        </SocialMediaContainer>
+        <RandomQuote />
+        <OrgInfoArea>
+          -
+          <Link href="/page/terms-and-conditions" passHref>
+            <a>Terms of Service </a>
+          </Link>
+          - | -
+          <Link href="/page/privacy-policy" passHref>
+            <a>Privacy Policy </a>
+          </Link>{' '}
+          {'- | '} ©Dev Launchers, 2021.
+        </OrgInfoArea>
+      </ThemeProvider>
     </Wrapper>
   );
 }

--- a/packages/UI/src/components/organisms/Navigation/Navigation.tsx
+++ b/packages/UI/src/components/organisms/Navigation/Navigation.tsx
@@ -1,5 +1,7 @@
 import Link from 'next/link';
 import React from 'react';
+import { ThemeProvider } from 'styled-components';
+import theme from '../../../styles/theme';
 import Logout from '../../../utils/Logout';
 import Box from '../../atoms/Box';
 import Button from '../../atoms/Button';
@@ -38,78 +40,80 @@ export default function Navigation({ user }: NavigationProps) {
   // const { userData } = useUserDataContext();
   return (
     <>
-      <Layer hasRainbowBottom={true} type="dark">
-        <Nav>
-          <Box justifyContent={'space-between'} alignItems={'center'}>
-            <Link href="/">
-              <a href="/">
-                <Box gap={'5px'} alignItems={'center'}>
-                  <img width="36" height="33" src={logo} alt="logo" />
-                  <Typography type="h3">Dev Launchers</Typography>
-                </Box>
-              </a>
-            </Link>
-            <NavWrapper>
-              <ul>
-                <Box gap={'16px'}>
-                  {Object.entries(links).map(([name, href], i) => (
-                    <li style={ListStyle} key={i}>
-                      <Link href={href} passHref>
-                        <a>{name}</a>
-                      </Link>
-                    </li>
-                  ))}
-                </Box>
-              </ul>
-              {userInfo.id === 0 ? (
-                <Box gap={'16px'}>
-                  <Button
-                    as="a"
-                    href={
-                      process.env.NEXT_PUBLIC_GOOGLE_AUTH_URL +
-                      '?redirectURL=https://devlaunchers.org/users/me'
-                    }
-                    buttonType="primary"
-                    buttonSize="standard"
-                  >
-                    Sign In
-                  </Button>
-                  <Button
-                    as="a"
-                    href={
-                      process.env.NEXT_PUBLIC_GOOGLE_AUTH_URL +
-                      '?redirectURL=https://devlaunchers.org/users/me'
-                    }
-                    buttonType="secondary"
-                    buttonSize="standard"
-                  >
-                    Create an Account
-                  </Button>
-                </Box>
-              ) : (
-                <Box gap={'16px'} alignItems={'center'}>
-                  <img
-                    width="36"
-                    height="33"
-                    src={userInfo.profilePictureUrl}
-                    alt="Profile avatar"
-                    style={{ borderRadius: '50%' }}
-                  />
-                  <Typography type="p">Hi {userInfo.name}</Typography>
-                  <Button
-                    buttonType="secondary"
-                    buttonSize="standard"
-                    onClick={Logout}
-                  >
-                    Log out
-                  </Button>
-                </Box>
-              )}
-            </NavWrapper>
-          </Box>
-          <MobileNavigation links={links} user={userInfo} />
-        </Nav>
-      </Layer>
+      <ThemeProvider theme={theme}>
+        <Layer hasRainbowBottom={true} type="dark">
+          <Nav>
+            <Box justifyContent={'space-between'} alignItems={'center'}>
+              <Link href="/">
+                <a href="/">
+                  <Box gap={'5px'} alignItems={'center'}>
+                    <img width="36" height="33" src={logo} alt="logo" />
+                    <Typography type="h3">Dev Launchers</Typography>
+                  </Box>
+                </a>
+              </Link>
+              <NavWrapper>
+                <ul>
+                  <Box gap={'16px'}>
+                    {Object.entries(links).map(([name, href], i) => (
+                      <li style={ListStyle} key={i}>
+                        <Link href={href} passHref>
+                          <a>{name}</a>
+                        </Link>
+                      </li>
+                    ))}
+                  </Box>
+                </ul>
+                {userInfo.id === 0 ? (
+                  <Box gap={'16px'}>
+                    <Button
+                      as="a"
+                      href={
+                        process.env.NEXT_PUBLIC_GOOGLE_AUTH_URL +
+                        '?redirectURL=https://devlaunchers.org/users/me'
+                      }
+                      buttonType="primary"
+                      buttonSize="standard"
+                    >
+                      Sign In
+                    </Button>
+                    <Button
+                      as="a"
+                      href={
+                        process.env.NEXT_PUBLIC_GOOGLE_AUTH_URL +
+                        '?redirectURL=https://devlaunchers.org/users/me'
+                      }
+                      buttonType="secondary"
+                      buttonSize="standard"
+                    >
+                      Create an Account
+                    </Button>
+                  </Box>
+                ) : (
+                  <Box gap={'16px'} alignItems={'center'}>
+                    <img
+                      width="36"
+                      height="33"
+                      src={userInfo.profilePictureUrl}
+                      alt="Profile avatar"
+                      style={{ borderRadius: '50%' }}
+                    />
+                    <Typography type="p">Hi {userInfo.name}</Typography>
+                    <Button
+                      buttonType="secondary"
+                      buttonSize="standard"
+                      onClick={Logout}
+                    >
+                      Log out
+                    </Button>
+                  </Box>
+                )}
+              </NavWrapper>
+            </Box>
+            <MobileNavigation links={links} user={userInfo} />
+          </Nav>
+        </Layer>
+      </ThemeProvider>
     </>
   );
 }


### PR DESCRIPTION
The `Layer` 'atom' wasn't able to access the `theme` object it was looking for, which at first I found strange because the styled component syntax was correct. After searching a bit, I realized that the **root of this is due to where the Layer was being used: the `Navigation` 'organism'**. __All styled components require that a parent component (any parent component that exists in the hierarchy before the child component is used) has been wrapped with a ThemeProvider that passes in an appropriate theme object.__ Before we moved to the external `packages` library and the atomic design structure this was a non-issue. We simply wrapped the entire app in a theme provider, and every descendant of the app component had access to the theme. Now, however, it looks like our 'organisms' do not have this same luxury. **My fix was to wrap the `Navigation` 'organism' component in a ThemeProvider and supply the theme object.** This then gave the child `Layer` component access to the theme. (Note: once I fixed this, the same issue existed in the `Footer`, so I patched things there as well)