### PR TITLE
remove styling to make links dark blue after they are clicked

### DIFF
--- a/packages/UI/src/components/atoms/NavLink/NavLink.tsx
+++ b/packages/UI/src/components/atoms/NavLink/NavLink.tsx
@@ -10,9 +10,6 @@ interface NavLinkProps {
 const NavLink = styled.a<NavLinkProps>`
   ${typographyStyles.navLink}
   color: ${({ theme }) => theme.colors.GREYSCALE_WHITE};
-  &:visited {
-    color: ${({ theme }) => theme.colors.BLUE};
-  }
   &:hover {
     color: ${({ theme }) => theme.colors.BLUE_200};
   }


### PR DESCRIPTION
This PR addresses the lack of contrast between the nav links and nav bar after users have visited a link.

Current appearance:
![image](https://user-images.githubusercontent.com/43216378/227729446-79c33599-b1b9-4324-a785-163afd11f0f3.png)


Appearance after this change:
![image](https://user-images.githubusercontent.com/43216378/227729488-4cfc5504-731d-4459-a24f-65853d9b0d50.png)
