### PR TITLE
Migrate dev-recruiters app to strapiv4 api endpoints

### DIFF
--- a/apps/dev-recruiters/src/pages/[slug]/index.tsx
+++ b/apps/dev-recruiters/src/pages/[slug]/index.tsx
@@ -14,7 +14,7 @@ export const getProjectsSlugs = async () => {
   // const res = await agent.Projects.list();
 
   const result: Project[] = await res.json();
-  let projects = result.data?.filter((p) => p.attributes.opportunities.data?.length > 0);
+  let projects = result?.data?.filter((p) => p.attributes.opportunities?.data?.length > 0);
   projects = projects.map(projects => projects.attributes);	// Flatten strapiv4 response
   const projectsSlugs = projects.map((project) => ({
     params: {
@@ -51,11 +51,11 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
   project = {
     ...project, 
     team: {
-      leaders: project.team ? project.team?.leaders?.map(leader => leader.leader.data.attributes) : ``,
-      members: project.team ? project.team?.members?.map(member => member.member.data.attributes) : ``
+      leaders: project.team ? project.team?.leaders?.map(leader => leader.leader?.data.attributes) : ``,
+      members: project.team ? project.team?.members?.map(member => member.member?.data.attributes) : ``
     },
-    interests: project.interests.data.map(interest => interest.attributes),
-    opportunities: project.opportunities.data.map(opportunity => opportunity.attributes)
+    interests: project.interests?.data.map(interest => interest.attributes),
+    opportunities: project.opportunities?.data.map(opportunity => opportunity.attributes)
     
   };
 
@@ -67,7 +67,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
   project.commitmentLevel = `${minCommitment} - ${maxCommitment}`;
 
   let opportunities: Opportunity[] = await opportuntiesRes.json();
-  opportunities = opportunities.data;
+  opportunities = opportunities?.data;
   opportunities = opportunities.map(opportunity => opportunity.attributes);
 
   return {

--- a/apps/dev-recruiters/src/pages/[slug]/index.tsx
+++ b/apps/dev-recruiters/src/pages/[slug]/index.tsx
@@ -8,14 +8,14 @@ import ProjectDetails from '../../components/modules/DetailedPage';
 import { agent } from '@devlaunchers/utility';
 
 export const getProjectsSlugs = async () => {
-  // const res = await fetch(
-  //   `${process.env.NEXT_PUBLIC_STRAPI_URL}/projects?_publicationState=live`
-  // );
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_STRAPI_URL}/projects?populate=deep&publicationState=live`
+  );
   // const res = await agent.Projects.list();
 
   const result: Project[] = await res.json();
-  const projects = result?.filter((p) => p.opportunities?.length > 0);
-
+  let projects = result.data?.filter((p) => p.attributes.opportunities.data?.length > 0);
+  projects = projects.map(projects => projects.attributes);	// Flatten strapiv4 response
   const projectsSlugs = projects.map((project) => ({
     params: {
       slug: project.slug,
@@ -37,13 +37,27 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
   // const projectsRes = await fetch(
   //   `${process.env.NEXT_PUBLIC_STRAPI_URL}/projects/${params.slug}`
   // );
+
   const projectsRes = await agent.Projects.get(params.slug as string);
-  
   const opportuntiesRes = await fetch(
-    `${process.env.NEXT_PUBLIC_STRAPI_URL}/opportunities?projects.slug=${params.slug}`
+    `${process.env.NEXT_PUBLIC_STRAPI_URL}/opportunities?populate=deep&filters[projects][slug][$eq]=${params.slug}`
   );
 
-  const project: Project = await projectsRes.json();
+  let project: Project = projectsRes[0].attributes;
+
+  // Restructure data returned from the API to flatten and make resemble data returned from old API
+  // Any relational data set up in Strapi should be flattened here
+  // We could `create a reusable function to handle this more elegantly
+  project = {
+    ...project, 
+    team: {
+      leaders: project.team ? project.team?.leaders?.map(leader => leader.leader.data.attributes) : ``,
+      members: project.team ? project.team?.members?.map(member => member.member.data.attributes) : ``
+    },
+    interests: project.interests.data.map(interest => interest.attributes),
+    opportunities: project.opportunities.data.map(opportunity => opportunity.attributes)
+    
+  };
 
   const commitments = project.opportunities.map(
     (opp) => opp.commitmentHoursPerWeek
@@ -52,12 +66,14 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
   const minCommitment = Math.min(...commitments);
   project.commitmentLevel = `${minCommitment} - ${maxCommitment}`;
 
-  const opportunites: Opportunity[] = await opportuntiesRes.json();
+  let opportunities: Opportunity[] = await opportuntiesRes.json();
+  opportunities = opportunities.data;
+  opportunities = opportunities.map(opportunity => opportunity.attributes);
 
   return {
     props: {
       project: project,
-      opportunites: opportunites,
+      opportunites: opportunities,
       maxCommitment,
       minCommitment,
     },

--- a/apps/dev-recruiters/src/pages/index.tsx
+++ b/apps/dev-recruiters/src/pages/index.tsx
@@ -15,14 +15,22 @@ export const getStaticProps: GetStaticProps = async (context) => {
   let opportunities: Opportunity[] = [];
   try {
     const result = await agent.Projects.list(
-      new URLSearchParams('_publicationState=live')
+      new URLSearchParams('populate=deep&publicationState=live')
     );
-    projects = result.filter((p: Project) => p.opportunities.length > 0);
-    projects.map((project) => {
+    projects = result.filter((p: Project) => p.attributes.opportunities.data.length > 0);
+
+    // Do weird map to flatten and morph data object returned from new Strapiv4 api
+    projects = projects.map(project => {
+      return {
+        ...project.attributes, 
+        opportunities: project.attributes.opportunities?.data.map(opportunity => opportunity.attributes)
+      }
+    });
+
+    projects = projects.map((project) => {
       const commitments = project.opportunities.map(
         (opp) => opp.commitmentHoursPerWeek
       );
-      // console.log(commitments);
       const maxCommitment = Math.max(...commitments);
       const minCommitment = Math.min(...commitments);
       project.commitmentLevel = `${minCommitment} - ${maxCommitment}`;
@@ -33,8 +41,12 @@ export const getStaticProps: GetStaticProps = async (context) => {
   }
 
   try {
-    const result = await agent.Opportunities.list();
-    opportunities = result.filter((o: Opportunity) => o.projects.length > 0);
+    const result = await agent.Opportunities.list(
+      new URLSearchParams('populate=deep')
+		);
+    opportunities = result.filter((o: Opportunity) => o.attributes.projects.data.length > 0);
+		// Do weird map to flatten and morph data object returned from new Strapiv4 api
+		opportunities = opportunities.map(opportunity => opportunity.attributes);
   } catch (error) {
     console.error('An error occurred while fetching Opportunities', error);
   }

--- a/packages/utility/agent.ts
+++ b/packages/utility/agent.ts
@@ -112,12 +112,14 @@ const Applicant = {
 
 const Projects = {
   list: (params?: URLSearchParams) =>
-    requests.get<Project[]>("/projects", params ? params : {populate: '*'}),
-  get: (slug: string, params?: URLSearchParams) => requests.get(`projects/${slug}`, params ? params : {populate: '*'})
+    requests.get<Project[]>("/projects", params ? params : {populate: 'deep'}),
+  get: (slug: string, params?: URLSearchParams) => requests.get(`projects`, params ? params+`&[filters][slug][$eq]=${slug}` : {populate: 'deep', '[filters][slug][$eq]': slug})
 };
 
 const Opportunities = {
-  list: () => requests.get<Opportunity[]>("opportunities"),
+  list: (params?: URLSearchParams) =>
+    requests.get<Opportunity[]>("/opportunities", params ? params : {populate: 'deep'}),
+  get: (slug: string, params?: URLSearchParams) => requests.get(`opportunities/${slug}`, params ? params : {populate: 'deep'})
 };
 
 const Ideas = {


### PR DESCRIPTION
Minus a few issues that need to be addressed in the backend, this PR *should* give the frontend everything it needs to make things work as they do currently when the endpoints are changes to strapiv4: https://github.com/dev-launchers/dev-launchers-platform/pull/1130

I did a lot of data restructuring in getStaticProps and paths in order to recreate the original data structure from v3, along with some agent changes. Additionally, this uses a new Strapiv4 plugin that let's use "deeply" populate api responses. You'll see that in areas where the GET parameter `populate=deep` is used. That's already merged into the main branch of the strapiv4 repo.