### PR TITLE
Change UI Library drowpdown z-index to 100 (from 0)

### DIFF
--- a/packages/UI/src/components/organisms/Dropdown/StyledDropdown.ts
+++ b/packages/UI/src/components/organisms/Dropdown/StyledDropdown.ts
@@ -43,6 +43,7 @@ export const OptionsContainer = styled.div<DropdownProps>`
   width: 100%;
   position: absolute;
   top: 100%;
+	z-index: 100;
 `;
 
 export const Options = styled.form<DropdownProps>`


### PR DESCRIPTION
This patch fixes the Dropdown component in the UI Library to display on top of components with a z-index set, instead of under. The z-index value of 100 was chosen arbitrarily, and may need to be revisited.

Before:
![image](https://github.com/dev-launchers/dev-launchers-platform/assets/46331884/a1a6a733-d966-4b8d-8ee1-4c7ba7b5f528)

After:
![image](https://github.com/dev-launchers/dev-launchers-platform/assets/46331884/af2974e0-b058-4fb8-b23d-00d51f699254)

