### PR TITLE
fixed search result when type in searchbar

### DIFF
--- a/apps/site-projects/src/components/modules/Projects/Projects.js
+++ b/apps/site-projects/src/components/modules/Projects/Projects.js
@@ -11,7 +11,7 @@ const Projects = ({ projects }) => {
 
   const options = {
     includeScore: true,
-    keys: ['interests?.interest'],
+    keys: ['interests.interest'],
     threshold: 0.3,
     ignoreFieldNorm: true,
   };


### PR DESCRIPTION
The 'searchResult' const was returning a empty array when typed in searchBar, as a result, no project was shown. So I removed the '?' from keys property in 'options':

```diff
- keys: ['interests?.interest'],
+ keys: ['interests.interest'],
```

with this, projects are now filtered by the 'interests' property.