### PR TITLE
do not render outdated meetings in projects details page

### DIFF
--- a/apps/site-projects/src/components/modules/Projects/Project/Sessions/Sessions.js
+++ b/apps/site-projects/src/components/modules/Projects/Project/Sessions/Sessions.js
@@ -37,7 +37,7 @@ const Sessions = ({ calendarId }) => {
         console.log(res);
         const items = [...res.data.items];
         const notCancelled = items.filter((item) => item.end !== undefined);
-        const now = DateTime.now().minus({ days: 6 });
+        const now = DateTime.now();
         const currentEvents = notCancelled.filter(
           (item) => DateTime.fromISO(item.start.dateTime) > now
         );


### PR DESCRIPTION
By removing the `.minus({ days: 6 })` method from the const `now`, it means that only future events will be rendered.

```diff
- const now = DateTime.now().minus({ days: 6 });
+ const now = DateTime.now();
```