### PR TITLE
hide milestones for not user and not members of the project team #1203

### DIFF
--- a/apps/site-projects/src/components/modules/Projects/Project/Project.js
+++ b/apps/site-projects/src/components/modules/Projects/Project/Project.js
@@ -23,6 +23,13 @@ import HelpBuild from "./HelpBuild";
 import Sessions from "./Sessions";
 import {useUserDataContext} from "../../../../context/UserDataContext"
 
+function isOnTeam(id, team) {
+  const leadersIds = team.leaders.map((leader) => leader.id);
+  const membersIds = team.members.map((member) => member.id);
+
+  return leadersIds.includes(id) || membersIds.includes(id);
+}
+
 const Project = ({ project, theme }) => {
   const router = useRouter();
   const roleRef = useRef();
@@ -36,6 +43,9 @@ const Project = ({ project, theme }) => {
   }
 
   const userData = useUserDataContext();
+
+  const checkIfIsOnTeam = isOnTeam(userData.userData.id, project.team);
+  const isLogged = userData.userData.id === 0 ? false : true
 
   return (
     <Wrapper>
@@ -59,7 +69,7 @@ const Project = ({ project, theme }) => {
         images={project?.Images}
       />
 			{/*}<Role ref={roleRef} data={project?.opportunities} projectSlug={project.slug} />{*/}
-      <Milestones data={project?.board?.ProjectMilestone} />
+      {isLogged && checkIfIsOnTeam ? <Milestones data={project?.board?.ProjectMilestone} /> : null}
       {<Sessions calendarId={project.calendarId} />}
       <Team data={project.team} />
       <JoinSupport

--- a/apps/site-projects/src/components/modules/Projects/Project/Sessions/Sessions.js
+++ b/apps/site-projects/src/components/modules/Projects/Project/Sessions/Sessions.js
@@ -37,7 +37,7 @@ const Sessions = ({ calendarId }) => {
         console.log(res);
         const items = [...res.data.items];
         const notCancelled = items.filter((item) => item.end !== undefined);
-        const now = DateTime.now().minus({ days: 6 });
+        const now = DateTime.now();
         const currentEvents = notCancelled.filter(
           (item) => DateTime.fromISO(item.start.dateTime) > now
         );


### PR DESCRIPTION
I created a function that checks if userId is present in leaders or members of team project and returns a boolean.

```js
function isOnTeam(id, team) {
  const leadersIds = team.leaders.map((leader) => leader.id);
  const membersIds = team.members.map((member) => member.id);

  return leadersIds.includes(id) || membersIds.includes(id);
}
```

Created two constants to hold booleans that check if user id is on the project team and if user is logged.

```js
const checkIfIsOnTeam = isOnTeam(userData.userData.id, project.team);
const isLogged = userData.userData.id === 0 ? false : true
```

So I created a conditional that only renders `Milestones` if user is logged and is part of the team project.

```js
{isLogged && checkIfIsOnTeam ? <Milestones data={project?.board?.ProjectMilestone} /> : null}
```