### PR TITLE
#1206 Hide project lead email

### DIFF
--- a/apps/site-projects/src/components/modules/Projects/Project/HelpBuild/HelpBuild.js
+++ b/apps/site-projects/src/components/modules/Projects/Project/HelpBuild/HelpBuild.js
@@ -13,7 +13,7 @@ const HelpBuild = () => (
         <h3>Join our mission!</h3>
         <p>
           We are looking for sponsors to fund the financial costs of different
-          operations, with your help we can build a better product!
+          operations. With your help we can build a better product!
         </p>
 
         <ButtonsContainer>

--- a/apps/site-projects/src/components/modules/Projects/Project/Team/Team.js
+++ b/apps/site-projects/src/components/modules/Projects/Project/Team/Team.js
@@ -42,9 +42,9 @@ const Team = ({ data }) => (
                 >
                   <span>{leader.profile?.displayName}</span>
                   <span>{leader.role}</span>
-                  <span>
+                  {/* <span>
                     <a href={`mailto:${leader.email}`}>Send Email</a>
-                  </span>
+                  </span> */}
                 </div>
               </div>
             ))}


### PR DESCRIPTION
I just commented the email section for now. So, it is hidden for all users.
If we need to make it visible for signed in users/ members then I can make changes accordingly.