### PR TITLE
fix close dialog box editor notification #1228

### DIFF
--- a/apps/site-projects/src/components/modules/Projects/Project/EditorNotification/EditorNotification.js
+++ b/apps/site-projects/src/components/modules/Projects/Project/EditorNotification/EditorNotification.js
@@ -25,17 +25,21 @@ function hasEditingAccess(user, project) {
 }
 
 const EditorNotification = ({ project }) => {
-
+	const [isClosed, setIsClosed] = React.useState(false)
   const user = useUserDataContext().userData;
 
-	if (!hasEditingAccess(user, project)) {
+	if (!hasEditingAccess(user, project) || isClosed) {
 		return (<></>);
+	}
+
+	function closeEditor() {
+		setIsClosed(true)
 	}
 
 	return (
 		<div style={{paddingTop: "1rem"}}>
 			<ThemeProvider theme={theme}>
-      	<Alert signal="notify">
+      	<Alert handleClose={closeEditor} signal="notify">
         	<h3>It looks like you have editing permissions for this page!</h3>
         	<p>
           	Head to the dashboard in Strapi to make changes to the content of this page.

--- a/apps/site-projects/src/components/modules/Projects/Project/Project.js
+++ b/apps/site-projects/src/components/modules/Projects/Project/Project.js
@@ -23,6 +23,13 @@ import HelpBuild from "./HelpBuild";
 import Sessions from "./Sessions";
 import {useUserDataContext} from "../../../../context/UserDataContext"
 
+function isOnTeam(id, team) {
+  const leadersIds = team.leaders.map((leader) => leader.id);
+  const membersIds = team.members.map((member) => member.id);
+
+  return leadersIds.includes(id) || membersIds.includes(id);
+}
+
 const Project = ({ project, theme }) => {
   const router = useRouter();
   const roleRef = useRef();
@@ -36,6 +43,9 @@ const Project = ({ project, theme }) => {
   }
 
   const userData = useUserDataContext();
+
+  const checkIfIsOnTeam = isOnTeam(userData.userData.id, project.team);
+  const isLogged = userData.userData.id === 0 ? false : true
 
   return (
     <Wrapper>
@@ -59,7 +69,7 @@ const Project = ({ project, theme }) => {
         images={project?.Images}
       />
 			{/*}<Role ref={roleRef} data={project?.opportunities} projectSlug={project.slug} />{*/}
-      <Milestones data={project?.board?.ProjectMilestone} />
+      {isLogged && checkIfIsOnTeam ? <Milestones data={project?.board?.ProjectMilestone} /> : null}
       {<Sessions calendarId={project.calendarId} />}
       <Team data={project.team} />
       <JoinSupport

--- a/apps/site-projects/src/components/modules/Projects/Project/Project.js
+++ b/apps/site-projects/src/components/modules/Projects/Project/Project.js
@@ -2,6 +2,7 @@
 import React, { useRef } from "react";
 // import Link from "next/link";
 // import Image from "next/image";
+import { DateTime } from "luxon";
 import { withTheme } from "styled-components";
 import { useRouter } from "next/router";
 import Button from "../../../common/Button";
@@ -30,6 +31,15 @@ function isOnTeam(id, team) {
   return leadersIds.includes(id) || membersIds.includes(id);
 }
 
+function hasPassedOneMonth(dateString) {
+  const currentDate = DateTime.local();
+  const completionDate = DateTime.fromISO(dateString);
+
+  const oneMonthLater = completionDate.plus({ months: 1 });
+
+  return currentDate >= oneMonthLater;
+}
+
 const Project = ({ project, theme }) => {
   const router = useRouter();
   const roleRef = useRef();
@@ -46,6 +56,7 @@ const Project = ({ project, theme }) => {
 
   const checkIfIsOnTeam = isOnTeam(userData.userData.id, project.team);
   const isLogged = userData.userData.id === 0 ? false : true
+  const milestoneIsOutdated = hasPassedOneMonth(project.board.ProjectMilestone[0].task[0].completionDate)
 
   return (
     <Wrapper>
@@ -69,7 +80,7 @@ const Project = ({ project, theme }) => {
         images={project?.Images}
       />
 			{/*}<Role ref={roleRef} data={project?.opportunities} projectSlug={project.slug} />{*/}
-      {isLogged && checkIfIsOnTeam ? <Milestones data={project?.board?.ProjectMilestone} /> : null}
+      {isLogged && checkIfIsOnTeam && !milestoneIsOutdated ? <Milestones data={project?.board?.ProjectMilestone} /> : null}
       {<Sessions calendarId={project.calendarId} />}
       <Team data={project.team} />
       <JoinSupport

--- a/apps/site-projects/src/components/modules/Projects/Project/Team/StyledTeam.js
+++ b/apps/site-projects/src/components/modules/Projects/Project/Team/StyledTeam.js
@@ -22,7 +22,4 @@ export const MemberImage = styled.img`
   width: 8.75rem;
   height: 8.75rem;
   flex-shrink: 0;
-  &:hover {
-    opacity: 0.5;
-  }
 `;

--- a/apps/site-projects/src/components/modules/Projects/Project/Team/Team.js
+++ b/apps/site-projects/src/components/modules/Projects/Project/Team/Team.js
@@ -25,13 +25,11 @@ const Team = ({ data }) => (
                 key={leader.id}
               >
                 <span>
-                  <a href="#">
-                    <MemberImage
-                        src={leader.profile?.profilePictureUrl}
-                        // src="https://pbs.twimg.com/profile_images/1157313327867092993/a09TxL_1_400x400.jpg"
-                        alt="Image of Team member"
-                      ></MemberImage>
-                  </a>
+                  <MemberImage
+                      src={leader.profile?.profilePictureUrl}
+                      // src="https://pbs.twimg.com/profile_images/1157313327867092993/a09TxL_1_400x400.jpg"
+                      alt="Image of Team member"
+                    ></MemberImage>
                 </span>
                 <div
                   style={{
@@ -63,13 +61,11 @@ const Team = ({ data }) => (
                 key={member.id}
               >
                 <span>
-                  <a href="#">
-                    <MemberImage
-                        src={member.profile?.profilePictureUrl}
-                        // src="https://pbs.twimg.com/profile_images/1157313327867092993/a09TxL_1_400x400.jpg"
-                        alt="Image of Team member"
-                      ></MemberImage>
-                  </a>
+                  <MemberImage
+                      src={member.profile?.profilePictureUrl}
+                      // src="https://pbs.twimg.com/profile_images/1157313327867092993/a09TxL_1_400x400.jpg"
+                      alt="Image of Team member"
+                    ></MemberImage>
                 </span>
                 <div
                   style={{

--- a/packages/UI/src/components/molecules/Alert/Alert.stories.tsx
+++ b/packages/UI/src/components/molecules/Alert/Alert.stories.tsx
@@ -1,9 +1,19 @@
 import type { ComponentStory, ComponentMeta } from '@storybook/react';
+import { LazyMotion, domAnimation } from 'framer-motion';
 import Alert from './Alert';
 
 export default {
   title: 'Molecules/Alert',
   component: Alert,
+  args: {
+    handleClose: (event) => {
+      console.log({ event });
+    },
+    isInitallyOpen: true,
+  },
+  decorators: [
+    (story) => <LazyMotion features={domAnimation}>{story()}</LazyMotion>,
+  ],
 } as ComponentMeta<typeof Alert>;
 
 export const NotificationAlert: ComponentStory<typeof Alert> = (args) => (

--- a/packages/UI/src/components/molecules/Alert/Alert.tsx
+++ b/packages/UI/src/components/molecules/Alert/Alert.tsx
@@ -6,6 +6,7 @@ import type { AlertProps } from '.';
 
 const Alert: React.FC<React.PropsWithChildren<AlertProps>> = ({
   signal = 'notify',
+  handleClose,
   children,
   ...rest
 }) => {
@@ -21,7 +22,9 @@ const Alert: React.FC<React.PropsWithChildren<AlertProps>> = ({
         <></>
       )}
       <Typography css={{ flex: 1 }}>{children}</Typography>
-      <Icons.Close />
+      <button>
+        <Icons.Close onClick={handleClose} />
+      </button>
     </Container>
   );
 };

--- a/packages/UI/src/components/molecules/Alert/Alert.tsx
+++ b/packages/UI/src/components/molecules/Alert/Alert.tsx
@@ -4,14 +4,32 @@ import Typography from '../../atoms/Typography';
 import { Container } from './StyledAlert';
 import type { AlertProps } from '.';
 
+const variants = {
+  open: { opacity: 1, y: 0 },
+  closed: { opacity: 0, y: '-100%' },
+};
+
 const Alert: React.FC<React.PropsWithChildren<AlertProps>> = ({
   signal = 'notify',
   handleClose,
+  isInitallyOpen = true,
   children,
   ...rest
 }) => {
+  const [isOpen, setIsOpen] = React.useState(isInitallyOpen);
   return (
-    <Container signal={signal} {...rest}>
+    <Container
+      signal={signal}
+      {...rest}
+      variants={variants}
+      initial={{ opacity: 0, y: '-100%' }}
+      animate={isOpen ? 'open' : 'closed'}
+      transition={{
+        type: 'spring',
+        stiffness: 260,
+        damping: 20,
+      }}
+    >
       {signal === 'error' ? (
         <Icons.Error />
       ) : signal === 'success' ? (
@@ -22,8 +40,13 @@ const Alert: React.FC<React.PropsWithChildren<AlertProps>> = ({
         <></>
       )}
       <Typography css={{ flex: 1 }}>{children}</Typography>
-      <button>
-        <Icons.Close onClick={handleClose} />
+      <button
+        onClick={(e) => {
+          setIsOpen((prev) => !prev);
+          handleClose?.(e);
+        }}
+      >
+        <Icons.Close />
       </button>
     </Container>
   );

--- a/packages/UI/src/components/molecules/Alert/StyledAlert.ts
+++ b/packages/UI/src/components/molecules/Alert/StyledAlert.ts
@@ -28,4 +28,10 @@ export const Container = styled.div<Styles>`
       `;
     }}
   }
+
+  > button {
+    border: none;
+    background: none;
+    cursor: pointer;
+  }
 `;

--- a/packages/UI/src/components/molecules/Alert/StyledAlert.ts
+++ b/packages/UI/src/components/molecules/Alert/StyledAlert.ts
@@ -1,9 +1,10 @@
+import { m } from 'framer-motion';
 import styled from 'styled-components';
 import type { AlertProps } from '.';
 
 type Styles = Omit<Partial<AlertProps>, 'text'>;
 
-export const Container = styled.div<Styles>`
+export const Container = styled(m.div)<Styles>`
   display: flex;
   align-items: center;
   gap: 1rem;
@@ -29,7 +30,7 @@ export const Container = styled.div<Styles>`
     }}
   }
 
-  > button {
+  & > button {
     border: none;
     background: none;
     cursor: pointer;

--- a/packages/UI/src/components/molecules/Alert/index.ts
+++ b/packages/UI/src/components/molecules/Alert/index.ts
@@ -1,4 +1,5 @@
 export interface AlertProps {
   signal?: 'notify' | 'success' | 'error';
+  handleClose?: () => void;
 }
 export { default } from './Alert';

--- a/packages/UI/src/components/molecules/Alert/index.ts
+++ b/packages/UI/src/components/molecules/Alert/index.ts
@@ -1,5 +1,6 @@
 export interface AlertProps {
   signal?: 'notify' | 'success' | 'error';
-  handleClose?: () => void;
+  handleClose?: (e?: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+  isInitallyOpen?: boolean;
 }
 export { default } from './Alert';


### PR DESCRIPTION
- [x] Created a `State  to check if editor `isClosed` or not, by default it's `false`, since the dialog starts open.
- [x] Created a condition that it will return a `fragment` if `isClosed` it's **true**.
- [x] Created a **function** responsible for close the `EditorNotification`.
- [x] Passed `closeEditor()` to the `Alert` component.

1. `EditorNotification.js`

```js
  const [isClosed, setIsClosed] = React.useState(false)

  if (!hasEditingAccess(user, project) || isClosed) {
    return (<></>);
  }
  
  function closeEditor() {
    setIsClosed(true)
  }

  /*
  ...
  */

        <Alert handleClose={closeEditor} signal="notify">
```

- [x] Expected `handleClose` as a **void function** in `AlertProps` file.

2. `index.ts`
```ts
export interface AlertProps {
  signal?: 'notify' | 'success' | 'error';
  handleClose?: () => void;
}
```

- [x] In **Alert component**, involved `Icons.Close` in a **button** to select it in `StyledAlert.ts`

3. `Alert.tsx`
```tsx
  <button>
    <Icons.Close onClick={handleClose} />
   </button>
```

- [x] Removed button border and background and added cursor pointer behavior.

4. `StyledAlert.ts`
```ts
> button {
    border: none;
    background: none;
    cursor: pointer;
  }
```

