### PR TITLE
Icons documentation

### DIFF
--- a/packages/UI/src/docs/System/Iconography.mdx
+++ b/packages/UI/src/docs/System/Iconography.mdx
@@ -1,21 +1,175 @@
 import { Meta, IconGallery, IconItem } from '@storybook/blocks';
-import * as Icons from '../../assets/icons';
+import * as CustomIcons from '../../assets/icons';
 import { icons } from 'lucide-react';
 
 <Meta title="Iconography" />
 
-# Iconography
+# Dev Launchers Iconography Documentation.
 
+## This page is made to make developers aware of what Icon sets we can use.
+
+<br />
+
+### We have two categories.
+
+<br />
+
+<details>
+  <summary>Custom Made Icons</summary>
+  <br/>
+    ### How to use
+
+```jsx
+import { Icons } from '@devlaunchers/components/src/assets';
+
+<Icons.NAME_OF_ICON_FROM_HERE />;
+```
+
+### How to modify custom icons.
+
+#### Adjusting custom icons can be done by passing any attribute that SVG accept as props. `stroke` or `fill` props can be used to achive different type of icon feel.
+
+<br />
+##### Example
+
+```jsx
+import { Icons } from '@devlaunchers/components/src/assets';
+
+<Icons.Bell stroke={'#283EB3'} />;
+
+<Icons.Bell fill={'#283EB3'} />;
+
+<Icons.Bell fill={'#283EB3'} height={32} width={32} />;
+```
+
+### How to create custom icons.
+
+#### Generally custom icons designed by Dev Launchers Universal design team before implimentation.
+
+```jsx
+// Fill icons
+// SVG is as copied from the Devlaunchers Universal design system
+function NameoftheIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      width="1em"
+      height="1em"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path
+        d="M22.2295 9.08847e-05H1.77049C1.30629 -0.0046333 0.859174 0.174984 0.52725 0.499529C0.195326 0.824074 0.00570713 1.26704 0 1.73123V22.2727C0.00673925 22.7362 0.196812 23.1782 0.528624 23.5019C0.860435 23.8256 1.30696 24.0046 1.77049 23.9999H22.2295C22.6937 24.0036 23.1406 23.8234 23.4723 23.4986C23.8041 23.1739 23.9938 22.731 24 22.2668V1.72532C23.9917 1.2625 23.8011 0.821646 23.4696 0.49859C23.138 0.175535 22.6924 -0.00361171 22.2295 9.08847e-05V9.08847e-05ZM7.11541 20.459H3.55279V8.99609H7.11541V20.459ZM5.34492 7.43413C4.9363 7.43452 4.53675 7.31371 4.19681 7.08698C3.85687 6.86025 3.59181 6.53779 3.43517 6.16039C3.27853 5.783 3.23735 5.36762 3.31683 4.96681C3.39631 4.566 3.59288 4.19777 3.88167 3.9087C4.17047 3.61963 4.53852 3.42271 4.93925 3.34285C5.33999 3.26299 5.75541 3.30378 6.13296 3.46006C6.51051 3.61634 6.83322 3.88109 7.06028 4.22081C7.28733 4.56053 7.40852 4.95996 7.40852 5.36858C7.40801 5.64016 7.35394 5.90898 7.24941 6.15964C7.14488 6.41031 6.99195 6.6379 6.79936 6.82939C6.60677 7.02088 6.37831 7.17251 6.12705 7.27561C5.87579 7.3787 5.60667 7.43123 5.33508 7.4302L5.34492 7.43413ZM20.459 20.459H16.8964V14.8819C16.8964 13.5541 16.8728 11.8446 15.0452 11.8446C13.2177 11.8446 12.9069 13.2924 12.9069 14.7954V20.459H9.35016V8.99609H12.7652V10.5698H12.8125C13.2885 9.66887 14.4492 8.71871 16.1823 8.71871C19.7902 8.71084 20.459 11.0853 20.459 14.1639V20.459Z"
+        fill={props.fill || 'black'}
+      />
+    </svg>
+  );
+}
+
+export default NameoftheIcon;
+```
+
+```jsx
+// Stroke icon
+// SVG is as copied from the Devlaunchers Universal design system
+function NameoftheIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      width="1em"
+      height="1em"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path
+        d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0v0zM12 9v4M12 16v.5"
+        stroke={props.stroke || '#A82B2B'}
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export default NameoftheIcon;
+```
+
+<br />
+
+<br />
+
+## Available custom icons
+
+<br />
 <IconGallery>
-  {Object.entries(Icons).map(([IconName, IconJSX]) => (
-    <IconItem name={IconName} key={IconName}>
-      <IconJSX />
-    </IconItem>
-  ))}
+{Object.entries(CustomIcons).map(([IconName, IconJSX]) => (
+  <IconItem name={IconName} key={IconName}>
+    <IconJSX />
+  </IconItem>
+))}
 
 </IconGallery>
+</details>
+<br /> 
+<details>
+   <summary>Lucide React Icons</summary>
+<br />
+    ### How to use
 
-## Lucide Icons
+```jsx
+import { NAME_OF_ICON_FROM_HERE } from 'lucide-react';
+
+<NAME_OF_ICON_FROM_HERE />;
+```
+
+### How to modify Lucide icons.
+
+#### Adjusting Lucide icons can be done by color, size and stroke-width props.
+
+<br />
+##### Color
+
+```jsx
+import { ThumbsUp } from 'lucide-react';
+<ThumbsUp color={'#fff'} />;
+```
+
+##### Size
+
+###### The size of all icons is 24px by 24px by default. The size is adjustable using the size prop and CSS.
+
+```jsx
+import { ThumbsUp } from 'lucide-react';
+<ThumbsUp size={32} />;
+```
+
+#### Resizing with Tailwind
+
+##### `h-* ` and `w-*` utilities can be used to adjust the size of the icon.
+
+```jsx
+import { ThumbsUp } from 'lucide-react';
+<ThumbsUp className="w-24 h-24" />;
+```
+
+##### Stroke width
+
+###### Lucide iocns are designed with SVG elements using strokes. These have a default `strokewidth` of `2px`.
+
+```jsx
+import { ThumbsUp } from 'lucide-react';
+
+<ThumbsUp strokeWidth={8} />;
+```
+
+<br />
+
+## Available Lucide icons
+
+<br />
 
 <IconGallery>
   {Object.entries(icons).map(([IconName, IconJSX]) => (
@@ -25,4 +179,4 @@ import { icons } from 'lucide-react';
   ))}
 </IconGallery>
 
-### TODO: Write documentations of how to use,create,modify Icons
+</details>

--- a/packages/UI/src/docs/System/Iconography.mdx
+++ b/packages/UI/src/docs/System/Iconography.mdx
@@ -22,7 +22,7 @@ import { icons } from 'lucide-react';
 ```jsx
 import { Icons } from '@devlaunchers/components/src/assets';
 
-<Icons.NAME_OF_ICON_FROM_HERE />;
+<Icons.Bell />;
 ```
 
 ### How to modify custom icons.
@@ -120,9 +120,9 @@ export default NameoftheIcon;
     ### How to use
 
 ```jsx
-import { NAME_OF_ICON_FROM_HERE } from 'lucide-react';
+import { ThumbsUp } from 'lucide-react';
 
-<NAME_OF_ICON_FROM_HERE />;
+<ThumbsUp />;
 ```
 
 ### How to modify Lucide icons.
@@ -134,7 +134,7 @@ import { NAME_OF_ICON_FROM_HERE } from 'lucide-react';
 
 ```jsx
 import { ThumbsUp } from 'lucide-react';
-<ThumbsUp color={'#fff'} />;
+<ThumbsUp className="text-blue-300" />;
 ```
 
 ##### Size

--- a/packages/UI/src/docs/System/Iconography.mdx
+++ b/packages/UI/src/docs/System/Iconography.mdx
@@ -1,14 +1,24 @@
 import { Meta, IconGallery, IconItem } from '@storybook/blocks';
 import * as Icons from '../../assets/icons';
+import * as LucideIcons from 'lucide-react';
 
-<Meta
-  title="Iconography"
-/>
+<Meta title="Iconography" />
 
 # Iconography
 
 <IconGallery>
   {Object.entries(Icons).map(([IconName, IconJSX]) => (
+    <IconItem name={IconName} key={IconName}>
+      <IconJSX />
+    </IconItem>
+  ))}
+
+</IconGallery>
+
+# Lucide Icons
+
+<IconGallery>
+  {Object.entries(LucideIcons).map(([IconName, IconJSX]) => (
     <IconItem name={IconName} key={IconName}>
       <IconJSX />
     </IconItem>

--- a/packages/UI/src/docs/System/Iconography.mdx
+++ b/packages/UI/src/docs/System/Iconography.mdx
@@ -1,6 +1,6 @@
 import { Meta, IconGallery, IconItem } from '@storybook/blocks';
 import * as Icons from '../../assets/icons';
-import * as LucideIcons from 'lucide-react';
+import { icons } from 'lucide-react';
 
 <Meta title="Iconography" />
 
@@ -15,10 +15,10 @@ import * as LucideIcons from 'lucide-react';
 
 </IconGallery>
 
-# Lucide Icons
+## Lucide Icons
 
 <IconGallery>
-  {Object.entries(LucideIcons).map(([IconName, IconJSX]) => (
+  {Object.entries(icons).map(([IconName, IconJSX]) => (
     <IconItem name={IconName} key={IconName}>
       <IconJSX />
     </IconItem>


### PR DESCRIPTION
Updated the documentation for both Custom icons and Lucide React icons. 
Showed.
- How to use and modify Lucide Icons
- How to use, modify and create custom icons. 
For custom icons, I will like  have more explanation on how to use the props mentioned in the UD documentation on icons CHARACTERESTICS so it could be covered in the documentation. Currently all the custom icons we have available do not follow the UD doc on Icons.