### PR TITLE
ops(wordpress): Move wordpress to knative deployment

### DIFF
--- a/production/wordpress.yaml
+++ b/production/wordpress.yaml
@@ -27,23 +27,13 @@ spec:
     requests:
       storage: 10Gi
 ---
-apiVersion: apps/v1
-kind: Deployment
+apiVersion: serving.knative.dev/v1
+kind: Service
 metadata:
-  name: wordpress
   namespace: platform-website
-  labels:
-    app: wordpress
+  name: wordpress
 spec:
-  selector:
-    matchLabels:
-      app: wordpress
-  strategy:
-    type: Recreate
   template:
-    metadata:
-      labels:
-        app: wordpress
     spec:
       containers:
         - image: wordpress:php8.0-apache
@@ -72,21 +62,6 @@ spec:
           ports:
             - containerPort: 80
               name: wordpress
-          resources:
-            limits:
-              cpu: 128m
-              memory: 300Mi
-            requests:
-              cpu: 32m
-              memory: 200Mi
-          livenessProbe:
-            httpGet:
-              path: /
-              port: wordpress
-            initialDelaySeconds: 60
-            periodSeconds: 10
-            timeoutSeconds: 10
-            failureThreshold: 5
           volumeMounts:
             - name: wordpress-persistent-storage
               mountPath: /var/www/html


### PR DESCRIPTION
The wordpress server is rarely used, yet it uses about 275 MB. By moving to knative deployment, we will spin up the container only when there is a request.