### PR TITLE
ops(wordpress): Remove conflict service definition for wordpress

### DIFF
--- a/production/wordpress.yaml
+++ b/production/wordpress.yaml
@@ -1,17 +1,3 @@
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: wordpress
-  namespace: platform-website
-  labels:
-    app: wordpress
-spec:
-  ports:
-    - port: 80
-  selector:
-    app: wordpress
----
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:


### PR DESCRIPTION
Knative will create its service definition for wordpress.