### PR TITLE
Changes to the Volunteer Application Form

### DIFF
--- a/apps/dev-recruiters/src/components/modules/FormPage/signUpForm.tsx
+++ b/apps/dev-recruiters/src/components/modules/FormPage/signUpForm.tsx
@@ -13,7 +13,7 @@ import {
   CloseButton,
   CloseIcon,
 } from '../DetailedPage/PositionCard/StyledPositionCard';
-import { GradientLine } from './styledSignupForm';
+import { GradientLine, SubmitButton } from './styledSignupForm';
 
 interface FormFields extends Omit<NewApplicant, 'level'> {
   level: NewApplicant['level'] | '';
@@ -135,7 +135,7 @@ export default function SignUpForm({
         }}
         validationSchema={SignupSchema}
       >
-        {({ errors, setFieldValue, touched, values }) => (
+        {(formik) => (
           <atoms.Box paddingInline="0.5rem" justifyContent="center">
             <CloseButton onClick={handleCloseModal}>
               <CloseIcon
@@ -152,7 +152,7 @@ export default function SignUpForm({
                 />
               </CloseIcon>
             </CloseButton>
-            <Form>
+            <form onSubmit={formik.handleSubmit}>
               <atoms.Box flexDirection="column" margin="auto">
                 <atoms.Box flexDirection="column">
                   {/* is the atoms.Layer setting correct? */}
@@ -179,8 +179,8 @@ export default function SignUpForm({
                     name="name"
                     required
                     // onChange={handleChange}
-                    touched={touched['name']}
-                    error={errors.name}
+                    touched={formik.touched['name']}
+                    error={formik.errors.name}
                   />
                   <Field
                     as={organisms.FormField}
@@ -189,8 +189,8 @@ export default function SignUpForm({
                     id="email"
                     name="email"
                     required
-                    touched={touched['email']}
-                    error={errors.email}
+                    touched={formik.touched['email']}
+                    error={formik.errors.email}
                   />
                   <atoms.Box gap="32px" flexDirection="column">
                     <Field
@@ -220,13 +220,15 @@ export default function SignUpForm({
                       min={5}
                       max={40}
                       initialValue={5}
-                      onChange={(value) => setFieldValue('commitment', +value)}
+                      onChange={(value) =>
+                        formik.setFieldValue('commitment', +value)
+                      }
                       withLabels
                       suffix=" hrs"
                       maxWidth="430px"
                     />
                     <atoms.Typography type="pSmall" css={{ color: 'red' }}>
-                      {errors.commitment}
+                      {formik.errors.commitment}
                     </atoms.Typography>
                   </atoms.Box>
                   <Field
@@ -236,15 +238,15 @@ export default function SignUpForm({
                     id="yearsOfExperience"
                     name="yearsOfExperience"
                     required
-                    touched={touched['yearsOfExperience']}
-                    error={errors.yearsOfExperience}
+                    touched={formik.touched['yearsOfExperience']}
+                    error={formik.errors.yearsOfExperience}
                   />
 
                   <Field
                     as={organisms.OpenResponse}
                     cols={50}
-                    touched={touched['experience']}
-                    error={errors.experience}
+                    touched={formik.touched['experience']}
+                    error={formik.errors.experience}
                     label="Please briefly describe your relevant experience"
                     placeholder="My experience with development / design is..."
                     required
@@ -280,8 +282,11 @@ export default function SignUpForm({
                     id="portfolioLink"
                     name="portfolioLink"
                     // onChange={handleChange}
-                    touched={touched.portfolioLink && !!values['portfolioLink']}
-                    error={errors.portfolioLink}
+                    touched={
+                      formik.touched.portfolioLink &&
+                      !!formik.values['portfolioLink']
+                    }
+                    error={formik.errors.portfolioLink}
                   />
                   <atoms.Typography type="p">
                     We require users to be 18 years old or older. Please confirm
@@ -293,6 +298,13 @@ export default function SignUpForm({
                     onChange={handleSetCheckCheckbox}
                     required
                   />
+                  <SubmitButton
+                    as="a"
+                    type="submit"
+                    onClick={formik.handleSubmit}
+                  >
+                    Styled Submit
+                  </SubmitButton>
                   <atoms.Box maxWidth="50%">
                     <atoms.Button
                       buttonSize="standard"
@@ -310,7 +322,7 @@ export default function SignUpForm({
                 handleOpenModal={handleOpenConfirmationModal}
                 handleCloseModal={handleCloseModal}
               />
-            </Form>
+            </form>
           </atoms.Box>
         )}
       </Formik>

--- a/apps/dev-recruiters/src/components/modules/FormPage/signUpForm.tsx
+++ b/apps/dev-recruiters/src/components/modules/FormPage/signUpForm.tsx
@@ -3,8 +3,8 @@ import FormErrorScroller from '@devlaunchers/components/src/utils/formErrorScrol
 import { Opportunity } from '@devlaunchers/models';
 import { NewApplicant } from '@devlaunchers/models/newApplicant';
 import { agent } from '@devlaunchers/utility';
-import { Field, Form, Formik, FormikHelpers } from 'formik';
-import { useState } from 'react';
+import { Field, Formik, FormikHelpers } from 'formik';
+import { MouseEventHandler, useState } from 'react';
 import { ThemeProvider } from 'styled-components';
 import theme from '@devlaunchers/dev-recruiters/src/styles/theme';
 import * as Yup from 'yup';
@@ -301,9 +301,11 @@ export default function SignUpForm({
                   <SubmitButton
                     as="a"
                     type="submit"
-                    onClick={formik.handleSubmit}
+                    onClick={
+                      formik.handleSubmit as unknown as MouseEventHandler<HTMLAnchorElement>
+                    }
                   >
-                    Submit
+                    Submit Application
                   </SubmitButton>
                   <atoms.Box maxWidth="50%">
                     <atoms.Button

--- a/apps/dev-recruiters/src/components/modules/FormPage/signUpForm.tsx
+++ b/apps/dev-recruiters/src/components/modules/FormPage/signUpForm.tsx
@@ -58,7 +58,12 @@ export default function SignUpForm({
         (number) => /^\d+(\.\d{1,2})?$/.test(number.toString())
       ),
     experience: Yup.string().required('Experience Field Entry is Required'),
-    accepted: Yup.boolean().required('Acceptance Field Entry is Required'),
+    isAgeOver18: Yup.boolean()
+      .required('Age over 18 Field is Required')
+      .oneOf([true], 'Age over 18 Field is Required'),
+    isTermsAgreed: Yup.boolean()
+      .required('Terms and Conditions is Required')
+      .oneOf([true], 'Terms and Conditions Field is Required'),
   });
   const [showConfirmationModal, setShowConfirmationModal] = useState(false);
   const [checkCheckbox, setCheckCheckbox] = useState<undefined | boolean>(
@@ -103,11 +108,14 @@ export default function SignUpForm({
           role: 'title' as string, //  role: position.title as string,
           project: { id: '1', slug: 'projectSlug' }, //router.query.slug as string },
           skills: [{ skill: '' }],
+          isAgeOver18: false,
+          isTermsAgreed: false,
         }}
         onSubmit={(
           values: NewApplicant,
           { setSubmitting }: FormikHelpers<NewApplicant>
         ) => {
+          console.log(values);
           setSubmitting(true);
           agent.Applicant.post({
             ...values,
@@ -292,12 +300,45 @@ export default function SignUpForm({
                     We require users to be 18 years old or older. Please confirm
                     below.
                   </atoms.Typography>
-                  <atoms.Checkbox
-                    label="I am 18 years old or older."
-                    disabled={false}
-                    onChange={handleSetCheckCheckbox}
+                  <Field
+                    as={atoms.Checkbox}
+                    type="checkbox"
+                    name="isAgeOver18"
+                    id="isAgeOver18"
                     required
+                    touched={formik.touched['isAgeOver18']}
+                    error={formik.errors.isAgeOver18}
+                    label="I am 18 years old or older."
+                    onChange={(e) =>
+                      formik.setFieldValue('isAgeOver18', e.target.checked)
+                    }
+                    checked={formik.values.isAgeOver18}
                   />
+                  {formik.errors.isAgeOver18 ? (
+                    <atoms.Typography type="pSmall" css={{ color: 'red' }}>
+                      {formik.errors.isAgeOver18}
+                    </atoms.Typography>
+                  ) : null}
+                  <Field
+                    as={atoms.Checkbox}
+                    type="checkbox"
+                    name="isTermsAgreed"
+                    id="isTermsAgreed"
+                    required
+                    touched={formik.touched['isTermsAgreed']}
+                    error={formik.errors.isTermsAgreed}
+                    label="I have read and agree to the Terms and Conditions.*"
+                    onChange={(e) => {
+                      formik.setFieldValue('isTermsAgreed', e.target.checked);
+                    }}
+                    checked={formik.values.isTermsAgreed}
+                  />
+                  {formik.errors.isTermsAgreed ? (
+                    <atoms.Typography type="pSmall" css={{ color: 'red' }}>
+                      {formik.errors.isTermsAgreed}
+                    </atoms.Typography>
+                  ) : null}
+
                   <SubmitButton
                     as="a"
                     type="submit"
@@ -307,15 +348,6 @@ export default function SignUpForm({
                   >
                     Submit Application
                   </SubmitButton>
-                  <atoms.Box maxWidth="50%">
-                    <atoms.Button
-                      buttonSize="standard"
-                      buttonType="primary"
-                      type="submit"
-                    >
-                      Submit
-                    </atoms.Button>
-                  </atoms.Box>
                 </atoms.Box>
               </atoms.Box>
               <FormErrorScroller focusAfterScroll />

--- a/apps/dev-recruiters/src/components/modules/FormPage/signUpForm.tsx
+++ b/apps/dev-recruiters/src/components/modules/FormPage/signUpForm.tsx
@@ -303,7 +303,7 @@ export default function SignUpForm({
                     type="submit"
                     onClick={formik.handleSubmit}
                   >
-                    Styled Submit
+                    Submit
                   </SubmitButton>
                   <atoms.Box maxWidth="50%">
                     <atoms.Button

--- a/apps/dev-recruiters/src/components/modules/FormPage/signUpForm.tsx
+++ b/apps/dev-recruiters/src/components/modules/FormPage/signUpForm.tsx
@@ -61,10 +61,12 @@ export default function SignUpForm({
     accepted: Yup.boolean().required('Acceptance Field Entry is Required'),
   });
   const [showConfirmationModal, setShowConfirmationModal] = useState(false);
-  const [checkCheckbox, setCheckCheckbox] = useState();
+  const [checkCheckbox, setCheckCheckbox] = useState<undefined | boolean>(
+    undefined
+  );
 
   const handleSetCheckCheckbox = () => {
-    setCheckCheckbox(checkCheckbox!);
+    setCheckCheckbox(!checkCheckbox);
   };
 
   const handleOpenConfirmationModal = () => {

--- a/apps/dev-recruiters/src/components/modules/FormPage/signUpForm.tsx
+++ b/apps/dev-recruiters/src/components/modules/FormPage/signUpForm.tsx
@@ -300,45 +300,50 @@ export default function SignUpForm({
                     We require users to be 18 years old or older. Please confirm
                     below.
                   </atoms.Typography>
-                  <Field
-                    as={atoms.Checkbox}
-                    type="checkbox"
-                    name="isAgeOver18"
-                    id="isAgeOver18"
-                    required
-                    touched={formik.touched['isAgeOver18']}
-                    error={formik.errors.isAgeOver18}
-                    label="I am 18 years old or older."
-                    onChange={(e) =>
-                      formik.setFieldValue('isAgeOver18', e.target.checked)
-                    }
-                    checked={formik.values.isAgeOver18}
-                  />
-                  {formik.errors.isAgeOver18 ? (
-                    <atoms.Typography type="pSmall" css={{ color: 'red' }}>
-                      {formik.errors.isAgeOver18}
-                    </atoms.Typography>
-                  ) : null}
-                  <Field
-                    as={atoms.Checkbox}
-                    type="checkbox"
-                    name="isTermsAgreed"
-                    id="isTermsAgreed"
-                    required
-                    touched={formik.touched['isTermsAgreed']}
-                    error={formik.errors.isTermsAgreed}
-                    label="I have read and agree to the Terms and Conditions.*"
-                    onChange={(e) => {
-                      formik.setFieldValue('isTermsAgreed', e.target.checked);
-                    }}
-                    checked={formik.values.isTermsAgreed}
-                  />
-                  {formik.errors.isTermsAgreed ? (
-                    <atoms.Typography type="pSmall" css={{ color: 'red' }}>
-                      {formik.errors.isTermsAgreed}
-                    </atoms.Typography>
-                  ) : null}
-
+                  <atoms.Box
+                    flexDirection="column"
+                    alignItems="flex-start"
+                    gap="1rem"
+                  >
+                    <Field
+                      as={atoms.Checkbox}
+                      type="checkbox"
+                      name="isAgeOver18"
+                      id="isAgeOver18"
+                      required
+                      touched={formik.touched['isAgeOver18']}
+                      error={formik.errors.isAgeOver18}
+                      label="I am 18 years old or older."
+                      onChange={(e) =>
+                        formik.setFieldValue('isAgeOver18', e.target.checked)
+                      }
+                      checked={formik.values.isAgeOver18}
+                    />
+                    {formik.errors.isAgeOver18 ? (
+                      <atoms.Typography type="pSmall" css={{ color: 'red' }}>
+                        {formik.errors.isAgeOver18}
+                      </atoms.Typography>
+                    ) : null}
+                    <Field
+                      as={atoms.Checkbox}
+                      type="checkbox"
+                      name="isTermsAgreed"
+                      id="isTermsAgreed"
+                      required
+                      touched={formik.touched['isTermsAgreed']}
+                      error={formik.errors.isTermsAgreed}
+                      label="I have read and agree to the Terms and Conditions.*"
+                      onChange={(e) => {
+                        formik.setFieldValue('isTermsAgreed', e.target.checked);
+                      }}
+                      checked={formik.values.isTermsAgreed}
+                    />
+                    {formik.errors.isTermsAgreed ? (
+                      <atoms.Typography type="pSmall" css={{ color: 'red' }}>
+                        {formik.errors.isTermsAgreed}
+                      </atoms.Typography>
+                    ) : null}
+                  </atoms.Box>
                   <SubmitButton
                     as="a"
                     type="submit"

--- a/apps/dev-recruiters/src/components/modules/FormPage/styledSignupForm.ts
+++ b/apps/dev-recruiters/src/components/modules/FormPage/styledSignupForm.ts
@@ -108,12 +108,17 @@ export const ErrorMsg = styled.div`
 `;
 
 export const SubmitButton = styled.button.attrs({ type: 'submit' })`
-  background-color: ${({ theme }) => theme?.colors?.White};
-  border-radius: 30px;
-  padding: 0.5rem;
-  width: 15%;
   color: ${({ theme }) => theme?.colors?.Black};
   cursor: pointer;
+  display: flex;
+  padding: var(--2, 8px) var(--6, 24px);
+  align-items: center;
+  width: 15%;
+  justify-content: right;
+  gap: var(--25, 10px);
+  border-radius: var(--2, 8px);
+  border: var(--0, 1px) solid var(--brand-secondary-nebula-600, #69349d);
+  background: var(--brand-alt-nebula-600, #69349d);
   @media (max-width: 768px) {
     width: 100%;
   }

--- a/apps/dev-recruiters/src/components/modules/FormPage/styledSignupForm.ts
+++ b/apps/dev-recruiters/src/components/modules/FormPage/styledSignupForm.ts
@@ -108,13 +108,28 @@ export const ErrorMsg = styled.div`
 `;
 
 export const SubmitButton = styled.button.attrs({ type: 'submit' })`
-  color: ${({ theme }) => theme?.colors?.Black};
+  color: var(--grayscale-50, #fff);
+  text-align: center;
+
+  /* to sort/Universal/button */
+  font-family: 'Nunito Sans';
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 150%; /* 24px */
+  letter-spacing: 0.64px;
+  text-transform: capitalize;
+
   cursor: pointer;
   display: flex;
   padding: var(--2, 8px) var(--6, 24px);
   align-items: center;
   width: 15%;
-  justify-content: right;
+
+  margin-top: 10px;
+  margin-left: auto;
+
+  justify-content: center;
   gap: var(--25, 10px);
   border-radius: var(--2, 8px);
   border: var(--0, 1px) solid var(--brand-secondary-nebula-600, #69349d);

--- a/apps/dev-recruiters/src/components/modules/FormPage/styledSignupForm.ts
+++ b/apps/dev-recruiters/src/components/modules/FormPage/styledSignupForm.ts
@@ -124,7 +124,7 @@ export const SubmitButton = styled.button.attrs({ type: 'submit' })`
   display: flex;
   padding: var(--2, 8px) var(--6, 24px);
   align-items: center;
-  width: 15%;
+  width: 45%;
 
   margin-top: 10px;
   margin-left: auto;

--- a/packages/UI/src/components/atoms/Checkbox/StyledCheckbox.ts
+++ b/packages/UI/src/components/atoms/Checkbox/StyledCheckbox.ts
@@ -54,7 +54,7 @@ export const Input = styled.input`
     &::before {
       content: '✔';
       font-size: 1.2em;
-      color: #fff;
+      color: black;
       position: absolute;
       left: 15%;
       top: 0%;

--- a/packages/UI/tsconfig.json
+++ b/packages/UI/tsconfig.json
@@ -10,6 +10,7 @@
     "noEmit": false,
     "composite": false,
     "incremental": true,
+    "outDir": "dist",
     "paths": {
       "@devlaunchers/core-lib/*": ["../../../packages/core-lib/src/*"],
       "@devlaunchers/core-lib": ["../../../packages/core-lib/src/index"]

--- a/packages/models/newApplicant.ts
+++ b/packages/models/newApplicant.ts
@@ -20,4 +20,6 @@ export interface NewApplicant {
   id?: string;
   project: { id: string; slug: string };
   level: keyof typeof SkillLevel;
+  isAgeOver18: boolean;
+  isTermsAgreed: boolean;
 }


### PR DESCRIPTION
Zenhub - https://app.zenhub.com/workspaces/devrecruit-team-644b85772003020cab70d47e/issues/gh/dev-launchers/dev-launchers-platform/1898

To match the Figma Styling the submit button and to incorporate the functionality of submit button
Added the 'isAgeOver18' and 'isTermsAgreed' columns to the Applicant Schema and the corresponding front-end changes