### PR TITLE
Release 2.20.0

### DIFF
--- a/staging/kustomization.yaml
+++ b/staging/kustomization.yaml
@@ -6,4 +6,4 @@ resources:
 images:
 - name: devlaunchers/platform-website
   newName: devlaunchers/platform-website
-  newTag: "e6cf654-202409151552" # {"$imagepolicy": "platform-website-staging:platform-website:tag"}
+  newTag: "a9877c4-202409161543" # {"$imagepolicy": "platform-website-staging:platform-website:tag"}


### PR DESCRIPTION
https://github.com/dev-launchers/dev-launchers-platform/pull/1985 didn't trigger a release, because none of the commit message followed https://github.com/semantic-release/semantic-release format.