### PR TITLE
feat(design): update to primitive colors

### DIFF
--- a/packages/tailwind-constructor/tokens.json
+++ b/packages/tailwind-constructor/tokens.json
@@ -1,0 +1,24970 @@
+{
+  "global": {},
+  "color-theme/dark-mode": {
+    "status": {
+      "default": {
+        "surface": {
+          "btn": {
+            "brand": {
+              "primary": {
+                "value": "{100%.brand.nebula.700}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{25%.brand.nebula.900}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{0%.transparent}",
+                "type": "color"
+              }
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.600}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{25%.grey.900}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{0%.transparent}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.alert.success.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.alert.success.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.alert.success.900}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.alert.info.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.alert.info.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.alert.info.900}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.alert.warning.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.alert.warning.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.alert.warning.900}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.alert.error.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{40%.alert.error.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.alert.error.900}",
+                  "type": "color"
+                }
+              }
+            }
+          },
+          "interactive": {
+            "brand": {
+              "primary": {
+                "value": "{100%.brand.nebula.700}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{25%.brand.nebula.900}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{0%.transparent}",
+                "type": "color"
+              }
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.600}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{25%.grey.900}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{0%.transparent}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.alert.success.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.alert.success.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.alert.success.900}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.alert.info.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.alert.info.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.alert.info.900}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.alert.warning.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.alert.warning.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.alert.warning.900}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.alert.error.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{40%.alert.error.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.alert.error.900}",
+                  "type": "color"
+                }
+              }
+            }
+          }
+        },
+        "indicator": {
+          "indicate": {
+            "value": "#ffffff",
+            "type": "color"
+          },
+          "border": {
+            "btn": {
+              "brand": {
+                "primary": {
+                  "value": "{100%.brand.nebula.400}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.brand.nebula.400}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              },
+              "grey": {
+                "primary": {
+                  "value": "{100%.grey.400}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.grey.400}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              },
+              "alert": {
+                "success": {
+                  "primary": {
+                    "value": "{100%.alert.success.600}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.success.600}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{0%.transparent}",
+                    "type": "color"
+                  }
+                },
+                "info": {
+                  "primary": {
+                    "value": "{100%.alert.info.600}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.info.600}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{0%.transparent}",
+                    "type": "color"
+                  }
+                },
+                "warning": {
+                  "primary": {
+                    "value": "{100%.alert.warning.600}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.warning.600}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{0%.transparent}",
+                    "type": "color"
+                  }
+                },
+                "error": {
+                  "primary": {
+                    "value": "{100%.alert.error.500}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.error.500}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{0%.transparent}",
+                    "type": "color"
+                  }
+                }
+              }
+            },
+            "interactive": {
+              "brand": {
+                "primary": {
+                  "value": "{100%.brand.nebula.400}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.brand.nebula.400}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              },
+              "grey": {
+                "primary": {
+                  "value": "{100%.grey.400}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.grey.400}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              },
+              "alert": {
+                "success": {
+                  "primary": {
+                    "value": "{100%.alert.success.600}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.success.600}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{0%.transparent}",
+                    "type": "color"
+                  }
+                },
+                "info": {
+                  "primary": {
+                    "value": "{100%.alert.info.600}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.info.600}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{0%.transparent}",
+                    "type": "color"
+                  }
+                },
+                "warning": {
+                  "primary": {
+                    "value": "{100%.alert.warning.600}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.warning.600}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{0%.transparent}",
+                    "type": "color"
+                  }
+                },
+                "error": {
+                  "primary": {
+                    "value": "{100%.alert.error.500}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.error.500}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{0%.transparent}",
+                    "type": "color"
+                  }
+                }
+              }
+            }
+          },
+          "surface": {
+            "btn": {
+              "brand": {
+                "primary": {
+                  "value": "{100%.brand.nebula.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.brand.nebula.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.brand.nebula.900}",
+                  "type": "color"
+                }
+              },
+              "grey": {
+                "primary": {
+                  "value": "{100%.grey.600}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.grey.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{5%.grey.400}",
+                  "type": "color"
+                }
+              },
+              "alert": {
+                "success": {
+                  "primary": {
+                    "value": "{100%.alert.success.800}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{25%.alert.success.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{5%.alert.success.900}",
+                    "type": "color"
+                  }
+                },
+                "info": {
+                  "primary": {
+                    "value": "{100%.alert.info.800}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{25%.alert.info.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{5%.alert.info.900}",
+                    "type": "color"
+                  }
+                },
+                "warning": {
+                  "primary": {
+                    "value": "{100%.alert.warning.800}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{25%.alert.warning.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{5%.alert.warning.900}",
+                    "type": "color"
+                  }
+                },
+                "error": {
+                  "primary": {
+                    "value": "{100%.alert.error.800}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{40%.alert.error.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{5%.alert.error.900}",
+                    "type": "color"
+                  }
+                }
+              }
+            },
+            "interactive": {
+              "brand": {
+                "primary": {
+                  "value": "{100%.brand.nebula.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.brand.nebula.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.brand.nebula.900}",
+                  "type": "color"
+                }
+              },
+              "grey": {
+                "primary": {
+                  "value": "{100%.grey.600}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.grey.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{5%.grey.400}",
+                  "type": "color"
+                }
+              },
+              "alert": {
+                "success": {
+                  "primary": {
+                    "value": "{100%.alert.success.800}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{25%.alert.success.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{5%.alert.success.900}",
+                    "type": "color"
+                  }
+                },
+                "info": {
+                  "primary": {
+                    "value": "{100%.alert.info.800}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{25%.alert.info.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{5%.alert.info.900}",
+                    "type": "color"
+                  }
+                },
+                "warning": {
+                  "primary": {
+                    "value": "{100%.alert.warning.800}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{25%.alert.warning.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{5%.alert.warning.900}",
+                    "type": "color"
+                  }
+                },
+                "error": {
+                  "primary": {
+                    "value": "{100%.alert.error.800}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{40%.alert.error.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{5%.alert.error.900}",
+                    "type": "color"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "content": {
+          "btn": {
+            "brand": {
+              "primary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.200}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.brand.nebula.400}",
+                "type": "color"
+              }
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.200}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.grey.300}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.200}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.success.400}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.200}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.info.400}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.200}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.warning.400}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.200}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.error.400}",
+                  "type": "color"
+                }
+              }
+            }
+          },
+          "interactive": {
+            "brand": {
+              "primary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.200}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.brand.nebula.400}",
+                "type": "color"
+              }
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.200}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.grey.300}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.200}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.success.400}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.200}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.info.400}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.200}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.warning.400}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.200}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.error.400}",
+                  "type": "color"
+                }
+              }
+            }
+          }
+        },
+        "border": {
+          "btn": {
+            "brand": {
+              "primary": {
+                "value": "{100%.brand.nebula.400}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.400}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{0%.transparent}",
+                "type": "color"
+              }
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.400}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.400}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{0%.transparent}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.alert.success.600}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.600}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.alert.info.600}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.600}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.alert.warning.600}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.600}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.alert.error.500}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.500}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              }
+            }
+          },
+          "interactive": {
+            "brand": {
+              "primary": {
+                "value": "{100%.brand.nebula.400}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.400}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{0%.transparent}",
+                "type": "color"
+              }
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.400}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.400}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{0%.transparent}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.alert.success.600}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.600}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.alert.info.600}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.600}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.alert.warning.600}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.600}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.alert.error.500}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.500}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              }
+            }
+          }
+        }
+      },
+      "disabled": {
+        "surface": {
+          "btn": {
+            "brand": {
+              "value": "{100%.grey.800}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.brand.nebula.700}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{25%.brand.nebula.900}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{25%.brand.nebula.900}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.600}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{25%.grey.900}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{25%.grey.900}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.alert.success.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.alert.success.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.alert.success.900}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.alert.info.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.alert.info.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.alert.info.900}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.alert.warning.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.alert.warning.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.alert.warning.900}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.alert.error.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{40%.alert.error.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.alert.error.900}",
+                  "type": "color"
+                }
+              }
+            }
+          },
+          "interactive": {
+            "brand": {
+              "value": "{100%.grey.800}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.brand.nebula.700}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{25%.brand.nebula.900}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{25%.brand.nebula.900}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.600}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{25%.grey.900}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{25%.grey.900}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.alert.success.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.alert.success.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.alert.success.900}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.alert.info.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.alert.info.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.alert.info.900}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.alert.warning.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.alert.warning.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.alert.warning.900}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.alert.error.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{40%.alert.error.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.alert.error.900}",
+                  "type": "color"
+                }
+              }
+            }
+          }
+        },
+        "border": {
+          "btn": {
+            "brand": {
+              "value": "{100%.grey.800}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.brand.nebula.400}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.400}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{0%.transparent}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.400}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.400}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{0%.transparent}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.alert.success.600}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.600}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.alert.info.600}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.600}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.alert.warning.600}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.600}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.alert.error.500}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.500}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              }
+            }
+          },
+          "interactive": {
+            "brand": {
+              "value": "{100%.grey.800}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.brand.nebula.400}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.400}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{0%.transparent}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.400}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.400}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{0%.transparent}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.alert.success.600}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.600}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.alert.info.600}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.600}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.alert.warning.600}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.600}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.alert.error.500}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.500}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              }
+            }
+          }
+        },
+        "content": {
+          "btn": {
+            "brand": {
+              "value": "{100%.grey.800}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.200}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.brand.nebula.400}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.200}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.grey.300}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.200}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.success.400}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.200}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.info.400}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.200}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.warning.400}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.200}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.error.400}",
+                  "type": "color"
+                }
+              }
+            }
+          },
+          "interactive": {
+            "brand": {
+              "value": "{100%.grey.800}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.200}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.brand.nebula.400}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.200}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.grey.300}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.200}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.success.400}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.200}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.info.400}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.200}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.warning.400}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.200}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.error.400}",
+                  "type": "color"
+                }
+              }
+            }
+          }
+        },
+        "indicator": {
+          "indicate": {
+            "value": "#ffffff",
+            "type": "color"
+          },
+          "surface": {
+            "btn": {
+              "brand": {
+                "value": "{100%.grey.800}",
+                "type": "color",
+                "primary": {
+                  "value": "{100%.brand.nebula.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.brand.nebula.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.brand.nebula.900}",
+                  "type": "color"
+                }
+              },
+              "muted": {
+                "value": "{100%.grey.700}",
+                "type": "color"
+              },
+              "grey": {
+                "primary": {
+                  "value": "{100%.grey.600}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.grey.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.grey.900}",
+                  "type": "color"
+                }
+              },
+              "alert": {
+                "success": {
+                  "primary": {
+                    "value": "{100%.alert.success.800}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{25%.alert.success.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{25%.alert.success.900}",
+                    "type": "color"
+                  }
+                },
+                "info": {
+                  "primary": {
+                    "value": "{100%.alert.info.800}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{25%.alert.info.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{25%.alert.info.900}",
+                    "type": "color"
+                  }
+                },
+                "warning": {
+                  "primary": {
+                    "value": "{100%.alert.warning.800}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{25%.alert.warning.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{25%.alert.warning.900}",
+                    "type": "color"
+                  }
+                },
+                "error": {
+                  "primary": {
+                    "value": "{100%.alert.error.800}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{40%.alert.error.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{25%.alert.error.900}",
+                    "type": "color"
+                  }
+                }
+              }
+            },
+            "interactive": {
+              "brand": {
+                "value": "{100%.grey.800}",
+                "type": "color",
+                "primary": {
+                  "value": "{100%.brand.nebula.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.brand.nebula.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.brand.nebula.900}",
+                  "type": "color"
+                }
+              },
+              "muted": {
+                "value": "{100%.grey.700}",
+                "type": "color"
+              },
+              "grey": {
+                "primary": {
+                  "value": "{100%.grey.600}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.grey.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.grey.900}",
+                  "type": "color"
+                }
+              },
+              "alert": {
+                "success": {
+                  "primary": {
+                    "value": "{100%.alert.success.800}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{25%.alert.success.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{25%.alert.success.900}",
+                    "type": "color"
+                  }
+                },
+                "info": {
+                  "primary": {
+                    "value": "{100%.alert.info.800}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{25%.alert.info.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{25%.alert.info.900}",
+                    "type": "color"
+                  }
+                },
+                "warning": {
+                  "primary": {
+                    "value": "{100%.alert.warning.800}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{25%.alert.warning.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{25%.alert.warning.900}",
+                    "type": "color"
+                  }
+                },
+                "error": {
+                  "primary": {
+                    "value": "{100%.alert.error.800}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{40%.alert.error.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{25%.alert.error.900}",
+                    "type": "color"
+                  }
+                }
+              }
+            }
+          },
+          "border": {
+            "btn": {
+              "brand": {
+                "value": "{100%.grey.800}",
+                "type": "color",
+                "primary": {
+                  "value": "{100%.brand.nebula.400}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.brand.nebula.400}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              },
+              "muted": {
+                "value": "{100%.grey.700}",
+                "type": "color"
+              },
+              "grey": {
+                "primary": {
+                  "value": "{100%.grey.400}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.grey.400}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              },
+              "alert": {
+                "success": {
+                  "primary": {
+                    "value": "{100%.alert.success.600}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.success.600}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{0%.transparent}",
+                    "type": "color"
+                  }
+                },
+                "info": {
+                  "primary": {
+                    "value": "{100%.alert.info.600}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.info.600}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{0%.transparent}",
+                    "type": "color"
+                  }
+                },
+                "warning": {
+                  "primary": {
+                    "value": "{100%.alert.warning.600}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.warning.600}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{0%.transparent}",
+                    "type": "color"
+                  }
+                },
+                "error": {
+                  "primary": {
+                    "value": "{100%.alert.error.500}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.error.500}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{0%.transparent}",
+                    "type": "color"
+                  }
+                }
+              }
+            },
+            "interactive": {
+              "brand": {
+                "value": "{100%.grey.800}",
+                "type": "color",
+                "primary": {
+                  "value": "{100%.brand.nebula.400}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.brand.nebula.400}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              },
+              "muted": {
+                "value": "{100%.grey.700}",
+                "type": "color"
+              },
+              "grey": {
+                "primary": {
+                  "value": "{100%.grey.400}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.grey.400}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              },
+              "alert": {
+                "success": {
+                  "primary": {
+                    "value": "{100%.alert.success.600}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.success.600}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{0%.transparent}",
+                    "type": "color"
+                  }
+                },
+                "info": {
+                  "primary": {
+                    "value": "{100%.alert.info.600}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.info.600}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{0%.transparent}",
+                    "type": "color"
+                  }
+                },
+                "warning": {
+                  "primary": {
+                    "value": "{100%.alert.warning.600}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.warning.600}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{0%.transparent}",
+                    "type": "color"
+                  }
+                },
+                "error": {
+                  "primary": {
+                    "value": "{100%.alert.error.500}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.error.500}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{0%.transparent}",
+                    "type": "color"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "hover": {
+        "surface": {
+          "btn": {
+            "brand": {
+              "value": "{100%.grey.800}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.brand.nebula.600}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{25%.brand.nebula.700}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{25%.brand.nebula.900}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.500}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{25%.grey.700}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{25%.grey.900}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.alert.success.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.alert.success.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.alert.success.700}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.alert.info.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.alert.info.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.alert.info.700}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.alert.warning.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.alert.warning.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.alert.warning.700}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.alert.error.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.alert.error.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.alert.error.700}",
+                  "type": "color"
+                }
+              }
+            }
+          },
+          "interactive": {
+            "brand": {
+              "value": "{100%.grey.800}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.brand.nebula.600}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{25%.brand.nebula.700}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{25%.brand.nebula.900}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.500}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{25%.grey.700}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{25%.grey.900}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.alert.success.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.alert.success.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.alert.success.700}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.alert.info.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.alert.info.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.alert.info.700}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.alert.warning.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.alert.warning.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.alert.warning.700}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.alert.error.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.alert.error.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.alert.error.700}",
+                  "type": "color"
+                }
+              }
+            }
+          }
+        },
+        "border": {
+          "btn": {
+            "brand": {
+              "value": "{100%.grey.800}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.brand.nebula.400}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.400}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.brand.nebula.400}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.300}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.400}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.grey.400}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.alert.success.400}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.400}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.success.400}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.alert.info.400}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.400}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.info.400}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.alert.warning.400}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.400}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.warning.400}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.alert.error.400}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.400}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.error.400}",
+                  "type": "color"
+                }
+              }
+            }
+          },
+          "interactive": {
+            "brand": {
+              "value": "{100%.grey.800}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.brand.nebula.400}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.400}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.brand.nebula.400}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.300}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.400}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.grey.400}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.alert.success.400}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.400}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.success.400}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.alert.info.400}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.400}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.info.400}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.alert.warning.400}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.400}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.warning.400}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.alert.error.400}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.400}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.error.400}",
+                  "type": "color"
+                }
+              }
+            }
+          }
+        },
+        "content": {
+          "btn": {
+            "brand": {
+              "value": "{100%.grey.800}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.100}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.brand.nebula.100}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.100}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.grey.100}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.100}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.success.100}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.100}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.info.100}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.100}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.warning.100}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.100}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.error.100}",
+                  "type": "color"
+                }
+              }
+            }
+          },
+          "interactive": {
+            "brand": {
+              "value": "{100%.grey.800}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.100}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.brand.nebula.100}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.100}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.grey.100}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.100}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.success.100}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.100}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.info.100}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.100}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.warning.100}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.100}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.error.100}",
+                  "type": "color"
+                }
+              }
+            }
+          }
+        },
+        "indicator": {
+          "indicate": {
+            "value": "#ffffff",
+            "type": "color"
+          },
+          "surface": {
+            "btn": {
+              "brand": {
+                "value": "{100%.grey.800}",
+                "type": "color",
+                "primary": {
+                  "value": "{100%.brand.nebula.400}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.brand.nebula.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.brand.nebula.900}",
+                  "type": "color"
+                }
+              },
+              "muted": {
+                "value": "{100%.grey.700}",
+                "type": "color"
+              },
+              "grey": {
+                "primary": {
+                  "value": "{100%.grey.500}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.grey.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.grey.900}",
+                  "type": "color"
+                }
+              },
+              "alert": {
+                "success": {
+                  "primary": {
+                    "value": "{100%.alert.success.700}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{25%.alert.success.700}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{25%.alert.success.700}",
+                    "type": "color"
+                  }
+                },
+                "info": {
+                  "primary": {
+                    "value": "{100%.alert.info.700}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{25%.alert.info.700}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{25%.alert.info.700}",
+                    "type": "color"
+                  }
+                },
+                "warning": {
+                  "primary": {
+                    "value": "{100%.alert.warning.700}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{25%.alert.warning.700}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{25%.alert.warning.700}",
+                    "type": "color"
+                  }
+                },
+                "error": {
+                  "primary": {
+                    "value": "{100%.alert.error.700}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{25%.alert.error.700}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{25%.alert.error.700}",
+                    "type": "color"
+                  }
+                }
+              }
+            },
+            "interactive": {
+              "brand": {
+                "value": "{100%.grey.800}",
+                "type": "color",
+                "primary": {
+                  "value": "{100%.brand.nebula.400}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.brand.nebula.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.brand.nebula.900}",
+                  "type": "color"
+                }
+              },
+              "muted": {
+                "value": "{100%.grey.700}",
+                "type": "color"
+              },
+              "grey": {
+                "primary": {
+                  "value": "{100%.grey.500}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.grey.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.grey.900}",
+                  "type": "color"
+                }
+              },
+              "alert": {
+                "success": {
+                  "primary": {
+                    "value": "{100%.alert.success.700}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{25%.alert.success.700}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{25%.alert.success.700}",
+                    "type": "color"
+                  }
+                },
+                "info": {
+                  "primary": {
+                    "value": "{100%.alert.info.700}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{25%.alert.info.700}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{25%.alert.info.700}",
+                    "type": "color"
+                  }
+                },
+                "warning": {
+                  "primary": {
+                    "value": "{100%.alert.warning.700}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{25%.alert.warning.700}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{25%.alert.warning.700}",
+                    "type": "color"
+                  }
+                },
+                "error": {
+                  "primary": {
+                    "value": "{100%.alert.error.700}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{25%.alert.error.700}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{25%.alert.error.700}",
+                    "type": "color"
+                  }
+                }
+              }
+            }
+          },
+          "border": {
+            "btn": {
+              "brand": {
+                "value": "{100%.grey.800}",
+                "type": "color",
+                "primary": {
+                  "value": "{100%.brand.nebula.400}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.brand.nebula.400}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.brand.nebula.400}",
+                  "type": "color"
+                }
+              },
+              "muted": {
+                "value": "{100%.grey.700}",
+                "type": "color"
+              },
+              "grey": {
+                "primary": {
+                  "value": "{100%.grey.300}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.grey.400}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.grey.400}",
+                  "type": "color"
+                }
+              },
+              "alert": {
+                "success": {
+                  "primary": {
+                    "value": "{100%.alert.success.400}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.success.400}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.success.400}",
+                    "type": "color"
+                  }
+                },
+                "info": {
+                  "primary": {
+                    "value": "{100%.alert.info.400}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.info.400}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.info.400}",
+                    "type": "color"
+                  }
+                },
+                "warning": {
+                  "primary": {
+                    "value": "{100%.alert.warning.400}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.warning.400}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.warning.400}",
+                    "type": "color"
+                  }
+                },
+                "error": {
+                  "primary": {
+                    "value": "{100%.alert.error.400}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.error.400}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.error.400}",
+                    "type": "color"
+                  }
+                }
+              }
+            },
+            "interactive": {
+              "brand": {
+                "value": "{100%.grey.800}",
+                "type": "color",
+                "primary": {
+                  "value": "{100%.brand.nebula.400}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.brand.nebula.400}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.brand.nebula.400}",
+                  "type": "color"
+                }
+              },
+              "muted": {
+                "value": "{100%.grey.700}",
+                "type": "color"
+              },
+              "grey": {
+                "primary": {
+                  "value": "{100%.grey.300}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.grey.400}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.grey.400}",
+                  "type": "color"
+                }
+              },
+              "alert": {
+                "success": {
+                  "primary": {
+                    "value": "{100%.alert.success.400}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.success.400}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.success.400}",
+                    "type": "color"
+                  }
+                },
+                "info": {
+                  "primary": {
+                    "value": "{100%.alert.info.400}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.info.400}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.info.400}",
+                    "type": "color"
+                  }
+                },
+                "warning": {
+                  "primary": {
+                    "value": "{100%.alert.warning.400}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.warning.400}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.warning.400}",
+                    "type": "color"
+                  }
+                },
+                "error": {
+                  "primary": {
+                    "value": "{100%.alert.error.400}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.error.400}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.error.400}",
+                    "type": "color"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "focus": {
+        "surface": {
+          "btn": {
+            "brand": {
+              "value": "{100%.grey.800}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.brand.nebula.600}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{25%.brand.nebula.900}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{25%.brand.nebula.900}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.500}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{40%.grey.900}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{40%.grey.900}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.alert.success.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{60%.alert.success.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{60%.alert.success.900}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.alert.info.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{60%.alert.info.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{60%.alert.info.900}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.alert.warning.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{60%.alert.warning.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{60%.alert.warning.900}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.alert.error.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{60%.alert.error.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{60%.alert.error.900}",
+                  "type": "color"
+                }
+              }
+            }
+          },
+          "interactive": {
+            "brand": {
+              "value": "{100%.grey.800}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.brand.nebula.600}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{25%.brand.nebula.900}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{25%.brand.nebula.900}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.500}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{40%.grey.900}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{40%.grey.900}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.alert.success.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{60%.alert.success.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{60%.alert.success.900}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.alert.info.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{60%.alert.info.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{60%.alert.info.900}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.alert.warning.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{60%.alert.warning.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{60%.alert.warning.900}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.alert.error.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{60%.alert.error.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{60%.alert.error.900}",
+                  "type": "color"
+                }
+              }
+            }
+          }
+        },
+        "border": {
+          "btn": {
+            "brand": {
+              "value": "{100%.grey.800}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.brand.nebula.400}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.400}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.brand.nebula.400}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.400}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.400}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.grey.400}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.alert.success.400}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.400}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.success.400}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.alert.info.400}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.400}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.info.400}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.alert.warning.400}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.400}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.warning.400}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.alert.error.400}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.400}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.error.400}",
+                  "type": "color"
+                }
+              }
+            }
+          },
+          "interactive": {
+            "brand": {
+              "value": "{100%.grey.800}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.brand.nebula.400}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.400}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.brand.nebula.400}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.400}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.400}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.grey.400}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.alert.success.400}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.400}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.success.400}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.alert.info.400}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.400}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.info.400}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.alert.warning.400}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.400}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.warning.400}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.alert.error.400}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.400}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.error.400}",
+                  "type": "color"
+                }
+              }
+            }
+          }
+        },
+        "content": {
+          "btn": {
+            "brand": {
+              "value": "{100%.grey.800}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.100}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.brand.nebula.100}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.100}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.grey.100}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.100}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.success.100}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.100}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.info.100}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.100}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.warning.100}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.100}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.error.100}",
+                  "type": "color"
+                }
+              }
+            }
+          },
+          "interactive": {
+            "brand": {
+              "value": "{100%.grey.800}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.100}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.brand.nebula.100}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.100}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.grey.100}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.100}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.success.100}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.100}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.info.100}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.100}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.warning.100}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.100}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.error.100}",
+                  "type": "color"
+                }
+              }
+            }
+          }
+        },
+        "indicator": {
+          "indicate": {
+            "value": "#ffffff",
+            "type": "color"
+          },
+          "border": {
+            "btn": {
+              "brand": {
+                "value": "{100%.grey.800}",
+                "type": "color",
+                "primary": {
+                  "value": "{100%.brand.nebula.400}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.brand.nebula.400}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.brand.nebula.400}",
+                  "type": "color"
+                }
+              },
+              "muted": {
+                "value": "{100%.grey.700}",
+                "type": "color"
+              },
+              "grey": {
+                "primary": {
+                  "value": "{100%.grey.400}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.grey.400}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.grey.400}",
+                  "type": "color"
+                }
+              },
+              "alert": {
+                "success": {
+                  "primary": {
+                    "value": "{100%.alert.success.400}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.success.400}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.success.400}",
+                    "type": "color"
+                  }
+                },
+                "info": {
+                  "primary": {
+                    "value": "{100%.alert.info.400}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.info.400}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.info.400}",
+                    "type": "color"
+                  }
+                },
+                "warning": {
+                  "primary": {
+                    "value": "{100%.alert.warning.400}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.warning.400}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.warning.400}",
+                    "type": "color"
+                  }
+                },
+                "error": {
+                  "primary": {
+                    "value": "{100%.alert.error.400}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.error.400}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.error.400}",
+                    "type": "color"
+                  }
+                }
+              }
+            },
+            "interactive": {
+              "brand": {
+                "value": "{100%.grey.800}",
+                "type": "color",
+                "primary": {
+                  "value": "{100%.brand.nebula.400}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.brand.nebula.400}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.brand.nebula.400}",
+                  "type": "color"
+                }
+              },
+              "muted": {
+                "value": "{100%.grey.700}",
+                "type": "color"
+              },
+              "grey": {
+                "primary": {
+                  "value": "{100%.grey.400}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.grey.400}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.grey.400}",
+                  "type": "color"
+                }
+              },
+              "alert": {
+                "success": {
+                  "primary": {
+                    "value": "{100%.alert.success.400}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.success.400}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.success.400}",
+                    "type": "color"
+                  }
+                },
+                "info": {
+                  "primary": {
+                    "value": "{100%.alert.info.400}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.info.400}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.info.400}",
+                    "type": "color"
+                  }
+                },
+                "warning": {
+                  "primary": {
+                    "value": "{100%.alert.warning.400}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.warning.400}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.warning.400}",
+                    "type": "color"
+                  }
+                },
+                "error": {
+                  "primary": {
+                    "value": "{100%.alert.error.400}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.error.400}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.error.400}",
+                    "type": "color"
+                  }
+                }
+              }
+            }
+          },
+          "surface": {
+            "btn": {
+              "brand": {
+                "value": "{100%.grey.800}",
+                "type": "color",
+                "primary": {
+                  "value": "{100%.brand.nebula.900}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{60%.brand.nebula.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{60%.brand.nebula.900}",
+                  "type": "color"
+                }
+              },
+              "muted": {
+                "value": "{100%.grey.700}",
+                "type": "color"
+              },
+              "grey": {
+                "primary": {
+                  "value": "{100%.grey.900}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{60%.grey.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{60%.grey.900}",
+                  "type": "color"
+                }
+              },
+              "alert": {
+                "success": {
+                  "primary": {
+                    "value": "{100%.alert.success.900}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{60%.alert.success.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{60%.alert.success.900}",
+                    "type": "color"
+                  }
+                },
+                "info": {
+                  "primary": {
+                    "value": "{100%.alert.info.900}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{60%.alert.info.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{60%.alert.info.900}",
+                    "type": "color"
+                  }
+                },
+                "warning": {
+                  "primary": {
+                    "value": "{100%.alert.warning.900}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{60%.alert.warning.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{60%.alert.warning.900}",
+                    "type": "color"
+                  }
+                },
+                "error": {
+                  "primary": {
+                    "value": "{100%.alert.error.900}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{60%.alert.error.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{60%.alert.error.900}",
+                    "type": "color"
+                  }
+                }
+              }
+            },
+            "interactive": {
+              "brand": {
+                "value": "{100%.grey.800}",
+                "type": "color",
+                "primary": {
+                  "value": "{100%.brand.nebula.900}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{60%.brand.nebula.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{60%.brand.nebula.900}",
+                  "type": "color"
+                }
+              },
+              "muted": {
+                "value": "{100%.grey.700}",
+                "type": "color"
+              },
+              "grey": {
+                "primary": {
+                  "value": "{100%.grey.900}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{60%.grey.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{60%.grey.900}",
+                  "type": "color"
+                }
+              },
+              "alert": {
+                "success": {
+                  "primary": {
+                    "value": "{100%.alert.success.900}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{60%.alert.success.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{60%.alert.success.900}",
+                    "type": "color"
+                  }
+                },
+                "info": {
+                  "primary": {
+                    "value": "{100%.alert.info.900}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{60%.alert.info.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{60%.alert.info.900}",
+                    "type": "color"
+                  }
+                },
+                "warning": {
+                  "primary": {
+                    "value": "{100%.alert.warning.900}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{60%.alert.warning.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{60%.alert.warning.900}",
+                    "type": "color"
+                  }
+                },
+                "error": {
+                  "primary": {
+                    "value": "{100%.alert.error.900}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{60%.alert.error.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{60%.alert.error.900}",
+                    "type": "color"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "active": {
+        "surface": {
+          "btn": {
+            "brand": {
+              "value": "{100%.grey.800}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.brand.nebula.700}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.900}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.brand.nebula.900}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.700}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.900}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.grey.900}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.alert.success.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.success.900}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.alert.info.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.info.900}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.alert.warning.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.warning.900}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.alert.error.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.error.900}",
+                  "type": "color"
+                }
+              }
+            }
+          },
+          "interactive": {
+            "brand": {
+              "value": "{100%.grey.800}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.brand.nebula.700}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.900}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.brand.nebula.900}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.700}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.900}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.grey.900}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.alert.success.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.success.900}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.alert.info.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.info.900}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.alert.warning.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.warning.900}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.alert.error.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.error.900}",
+                  "type": "color"
+                }
+              }
+            }
+          }
+        },
+        "border": {
+          "btn": {
+            "brand": {
+              "value": "{100%.grey.800}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.brand.nebula.500}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.700}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.brand.nebula.700}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.500}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.700}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.grey.700}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.alert.success.500}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.success.700}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.alert.info.500}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.info.700}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.alert.warning.500}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.warning.700}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.alert.error.500}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.error.700}",
+                  "type": "color"
+                }
+              }
+            }
+          },
+          "interactive": {
+            "brand": {
+              "value": "{100%.grey.800}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.brand.nebula.500}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.700}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.brand.nebula.700}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.500}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.700}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.grey.700}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.alert.success.500}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.success.700}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.alert.info.500}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.info.700}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.alert.warning.500}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.warning.700}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.alert.error.500}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.error.700}",
+                  "type": "color"
+                }
+              }
+            }
+          }
+        },
+        "content": {
+          "btn": {
+            "brand": {
+              "value": "{100%.grey.800}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.50}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.brand.nebula.50}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.50}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.success.50}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.50}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.info.50}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.50}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.warning.50}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.50}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.error.50}",
+                  "type": "color"
+                }
+              }
+            }
+          },
+          "interactive": {
+            "brand": {
+              "value": "{100%.grey.800}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.50}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.brand.nebula.50}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.50}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.success.50}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.50}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.info.50}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.50}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.warning.50}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.50}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.error.50}",
+                  "type": "color"
+                }
+              }
+            }
+          }
+        },
+        "indicator": {
+          "indicate": {
+            "value": "#ffffff",
+            "type": "color"
+          },
+          "surface": {
+            "btn": {
+              "brand": {
+                "primary": {
+                  "value": "{100%.brand.nebula.300}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.brand.nebula.600}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.brand.nebula.600}",
+                  "type": "color"
+                }
+              },
+              "grey": {
+                "primary": {
+                  "value": "{100%.grey.300}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.grey.600}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.grey.600}",
+                  "type": "color"
+                }
+              },
+              "alert": {
+                "success": {
+                  "primary": {
+                    "value": "{100%.alert.success.300}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.success.600}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.success.600}",
+                    "type": "color"
+                  }
+                },
+                "info": {
+                  "primary": {
+                    "value": "{100%.alert.info.300}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.info.600}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.info.600}",
+                    "type": "color"
+                  }
+                },
+                "warning": {
+                  "primary": {
+                    "value": "{100%.alert.warning.300}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.warning.600}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.warning.600}",
+                    "type": "color"
+                  }
+                },
+                "error": {
+                  "primary": {
+                    "value": "{100%.alert.error.300}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.error.600}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.error.600}",
+                    "type": "color"
+                  }
+                }
+              }
+            },
+            "interactive": {
+              "brand": {
+                "primary": {
+                  "value": "{100%.brand.nebula.300}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.brand.nebula.600}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.brand.nebula.600}",
+                  "type": "color"
+                }
+              },
+              "grey": {
+                "primary": {
+                  "value": "{100%.grey.300}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.grey.600}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.grey.600}",
+                  "type": "color"
+                }
+              },
+              "alert": {
+                "success": {
+                  "primary": {
+                    "value": "{100%.alert.success.300}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.success.600}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.success.600}",
+                    "type": "color"
+                  }
+                },
+                "info": {
+                  "primary": {
+                    "value": "{100%.alert.info.300}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.info.600}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.info.600}",
+                    "type": "color"
+                  }
+                },
+                "warning": {
+                  "primary": {
+                    "value": "{100%.alert.warning.300}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.warning.600}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.warning.600}",
+                    "type": "color"
+                  }
+                },
+                "error": {
+                  "primary": {
+                    "value": "{100%.alert.error.300}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.error.600}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.error.600}",
+                    "type": "color"
+                  }
+                }
+              }
+            }
+          },
+          "border": {
+            "btn": {
+              "brand": {
+                "value": "{100%.grey.800}",
+                "type": "color",
+                "primary": {
+                  "value": "{100%.brand.nebula.100}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.brand.nebula.400}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.brand.nebula.400}",
+                  "type": "color"
+                }
+              },
+              "muted": {
+                "value": "{100%.grey.700}",
+                "type": "color"
+              },
+              "grey": {
+                "primary": {
+                  "value": "{100%.grey.100}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.grey.400}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.grey.400}",
+                  "type": "color"
+                }
+              },
+              "alert": {
+                "success": {
+                  "primary": {
+                    "value": "{100%.alert.success.100}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.success.400}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.success.400}",
+                    "type": "color"
+                  }
+                },
+                "info": {
+                  "primary": {
+                    "value": "{100%.alert.info.100}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.info.400}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.info.400}",
+                    "type": "color"
+                  }
+                },
+                "warning": {
+                  "primary": {
+                    "value": "{100%.alert.warning.100}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.warning.400}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.warning.400}",
+                    "type": "color"
+                  }
+                },
+                "error": {
+                  "primary": {
+                    "value": "{100%.alert.error.100}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.error.400}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.error.400}",
+                    "type": "color"
+                  }
+                }
+              }
+            },
+            "interactive": {
+              "brand": {
+                "value": "{100%.grey.800}",
+                "type": "color",
+                "primary": {
+                  "value": "{100%.brand.nebula.100}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.brand.nebula.400}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.brand.nebula.400}",
+                  "type": "color"
+                }
+              },
+              "muted": {
+                "value": "{100%.grey.700}",
+                "type": "color"
+              },
+              "grey": {
+                "primary": {
+                  "value": "{100%.grey.100}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.grey.400}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.grey.400}",
+                  "type": "color"
+                }
+              },
+              "alert": {
+                "success": {
+                  "primary": {
+                    "value": "{100%.alert.success.100}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.success.400}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.success.400}",
+                    "type": "color"
+                  }
+                },
+                "info": {
+                  "primary": {
+                    "value": "{100%.alert.info.100}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.info.400}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.info.400}",
+                    "type": "color"
+                  }
+                },
+                "warning": {
+                  "primary": {
+                    "value": "{100%.alert.warning.100}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.warning.400}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.warning.400}",
+                    "type": "color"
+                  }
+                },
+                "error": {
+                  "primary": {
+                    "value": "{100%.alert.error.100}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.error.400}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.error.400}",
+                    "type": "color"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "static": {
+      "core": {
+        "jupiter": {
+          "value": "{100%.brand.jupiter.500}",
+          "type": "color"
+        },
+        "saturn": {
+          "value": "{100%.brand.saturn.500}",
+          "type": "color"
+        },
+        "neptune": {
+          "value": "{100%.brand.neptune.500}",
+          "type": "color"
+        },
+        "uranus": {
+          "value": "{100%.brand.uranus.500}",
+          "type": "color"
+        },
+        "cosmic": {
+          "value": "{100%.brand.cosmic.500}",
+          "type": "color"
+        },
+        "nebula": {
+          "value": "{100%.brand.nebula.500}",
+          "type": "color"
+        }
+      },
+      "surface": {
+        "grey": {
+          "pure": {
+            "value": "{100%.grey.900}",
+            "type": "color"
+          },
+          "brand": {
+            "value": "{100%.grey.800}",
+            "type": "color"
+          },
+          "muted": {
+            "value": "{100%.grey.700}",
+            "type": "color"
+          },
+          "transparent": {
+            "value": "{0%.transparent}",
+            "type": "color"
+          }
+        },
+        "brand": {
+          "uranus": {
+            "value": "{100%.brand.uranus.800}",
+            "type": "color"
+          },
+          "jupiter": {
+            "value": "{100%.brand.jupiter.800}",
+            "type": "color"
+          },
+          "neptune": {
+            "value": "{100%.brand.neptune.800}",
+            "type": "color"
+          },
+          "saturn": {
+            "value": "{100%.brand.saturn.800}",
+            "type": "color"
+          },
+          "cosmic": {
+            "value": "{100%.brand.cosmic.700}",
+            "type": "color"
+          },
+          "nebula": {
+            "value": "{100%.brand.nebula.700}",
+            "type": "color"
+          }
+        },
+        "alert": {
+          "info": {
+            "value": "{100%.alert.info.800}",
+            "type": "color"
+          },
+          "warning": {
+            "value": "{100%.alert.warning.800}",
+            "type": "color"
+          },
+          "success": {
+            "value": "{100%.alert.success.700}",
+            "type": "color"
+          },
+          "error": {
+            "value": "{100%.alert.error.700}",
+            "type": "color"
+          }
+        }
+      },
+      "border": {
+        "grey": {
+          "pure": {
+            "value": "{100%.grey.50}",
+            "type": "color"
+          },
+          "brand": {
+            "value": "{100%.grey.100}",
+            "type": "color"
+          },
+          "muted": {
+            "value": "{100%.grey.300}",
+            "type": "color"
+          }
+        },
+        "brand": {
+          "jupiter": {
+            "value": "{100%.brand.jupiter.400}",
+            "type": "color"
+          },
+          "uranus": {
+            "value": "{100%.brand.uranus.400}",
+            "type": "color"
+          },
+          "neptune": {
+            "value": "{100%.brand.neptune.400}",
+            "type": "color"
+          },
+          "saturn": {
+            "value": "{100%.brand.saturn.400}",
+            "type": "color"
+          },
+          "cosmic": {
+            "value": "{100%.brand.cosmic.300}",
+            "type": "color"
+          },
+          "nebula": {
+            "value": "{100%.brand.nebula.300}",
+            "type": "color"
+          }
+        },
+        "alert": {
+          "info": {
+            "value": "{100%.alert.info.400}",
+            "type": "color"
+          },
+          "warning": {
+            "value": "{100%.alert.warning.400}",
+            "type": "color"
+          },
+          "success": {
+            "value": "{100%.alert.success.400}",
+            "type": "color"
+          },
+          "error": {
+            "value": "{100%.alert.error.400}",
+            "type": "color"
+          }
+        }
+      },
+      "content": {
+        "text": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.50}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.100}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.300}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "jupiter": {
+              "value": "{100%.brand.jupiter.400}",
+              "type": "color"
+            },
+            "uranus": {
+              "value": "{100%.brand.uranus.400}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.400}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.400}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.300}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.200}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.300}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.300}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.300}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.300}",
+              "type": "color"
+            }
+          }
+        },
+        "icon": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.50}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.100}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.300}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "jupiter": {
+              "value": "{100%.brand.jupiter.400}",
+              "type": "color"
+            },
+            "uranus": {
+              "value": "{100%.brand.uranus.400}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.400}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.400}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.300}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.200}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.300}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.300}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.300}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.300}",
+              "type": "color"
+            }
+          }
+        }
+      },
+      "effect": {
+        "shadow": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.600}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.500}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "uranus": {
+              "value": "{100%.brand.uranus.600}",
+              "type": "color"
+            },
+            "jupiter": {
+              "value": "{100%.brand.jupiter.600}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.600}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.600}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.600}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.600}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.700}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.600}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.600}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.600}",
+              "type": "color"
+            }
+          }
+        },
+        "overlay": {
+          "grey": {
+            "strong": {
+              "value": "{60%.grey.500}",
+              "type": "color"
+            },
+            "base": {
+              "value": "{40%.grey.600}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{25%.grey.600}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "jupiter": {
+              "strong": {
+                "value": "{60%.brand.jupiter.800}",
+                "type": "color"
+              },
+              "base": {
+                "value": "{40%.brand.jupiter.800}",
+                "type": "color"
+              },
+              "muted": {
+                "value": "{25%.brand.jupiter.900}",
+                "type": "color"
+              }
+            },
+            "saturn": {
+              "strong": {
+                "value": "{60%.brand.saturn.800}",
+                "type": "color"
+              },
+              "base": {
+                "value": "{40%.brand.saturn.800}",
+                "type": "color"
+              },
+              "muted": {
+                "value": "{25%.brand.saturn.900}",
+                "type": "color"
+              }
+            },
+            "uranus": {
+              "strong": {
+                "value": "{60%.brand.uranus.800}",
+                "type": "color"
+              },
+              "base": {
+                "value": "{40%.brand.uranus.800}",
+                "type": "color"
+              },
+              "muted": {
+                "value": "{25%.brand.uranus.900}",
+                "type": "color"
+              }
+            },
+            "neptune": {
+              "strong": {
+                "value": "{60%.brand.neptune.800}",
+                "type": "color"
+              },
+              "base": {
+                "value": "{40%.brand.neptune.800}",
+                "type": "color"
+              },
+              "muted": {
+                "value": "{25%.brand.neptune.900}",
+                "type": "color"
+              }
+            },
+            "nebula": {
+              "strong": {
+                "value": "{60%.brand.nebula.800}",
+                "type": "color"
+              },
+              "base": {
+                "value": "{40%.brand.nebula.800}",
+                "type": "color"
+              },
+              "muted": {
+                "value": "{25%.brand.nebula.900}",
+                "type": "color"
+              }
+            },
+            "cosmic": {
+              "strong": {
+                "value": "{60%.brand.cosmic.800}",
+                "type": "color"
+              },
+              "base": {
+                "value": "{40%.brand.cosmic.800}",
+                "type": "color"
+              },
+              "muted": {
+                "value": "{25%.brand.cosmic.900}",
+                "type": "color"
+              }
+            }
+          },
+          "alert": {
+            "success": {
+              "strong": {
+                "value": "{60%.alert.success.800}",
+                "type": "color"
+              },
+              "base": {
+                "value": "{40%.alert.success.800}",
+                "type": "color"
+              },
+              "muted": {
+                "value": "{25%.alert.success.900}",
+                "type": "color"
+              }
+            },
+            "info": {
+              "strong": {
+                "value": "{60%.alert.info.800}",
+                "type": "color"
+              },
+              "base*": {
+                "value": "{40%.alert.info.900}",
+                "type": "color"
+              },
+              "muted": {
+                "value": "{25%.alert.info.900}",
+                "type": "color"
+              }
+            },
+            "warning": {
+              "strong": {
+                "value": "{60%.alert.warning.800}",
+                "type": "color"
+              },
+              "base": {
+                "value": "{40%.alert.warning.800}",
+                "type": "color"
+              },
+              "muted": {
+                "value": "{25%.alert.warning.900}",
+                "type": "color"
+              }
+            },
+            "error": {
+              "strong": {
+                "value": "{60%.alert.error.800}",
+                "type": "color"
+              },
+              "base*": {
+                "value": "{40%.alert.error.700}",
+                "type": "color"
+              },
+              "muted": {
+                "value": "{25%.alert.error.900}",
+                "type": "color"
+              }
+            }
+          }
+        }
+      }
+    },
+    "depreciated": {
+      "hover*": {
+        "bg": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.800}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.600}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "uranus": {
+              "value": "{100%.brand.uranus.700}",
+              "type": "color"
+            },
+            "jupiter": {
+              "value": "{100%.brand.jupiter.700}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.700}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.700}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.500}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.400}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.700}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.700}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.700}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.700}",
+              "type": "color"
+            }
+          }
+        },
+        "border": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.50}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.50}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.50}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "jupiter": {
+              "value": "{100%.brand.jupiter.100}",
+              "type": "color"
+            },
+            "uranus": {
+              "value": "{100%.brand.uranus.100}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.100}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.100}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.100}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.100}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.100}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.100}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.100}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.100}",
+              "type": "color"
+            }
+          }
+        },
+        "text": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.50}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.50}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.50}",
+              "type": "color"
+            },
+            "pure-inv": {
+              "value": "{100%.grey.900}",
+              "type": "color"
+            },
+            "brand-inv": {
+              "value": "{100%.grey.800}",
+              "type": "color"
+            },
+            "muted-inv": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "jupiter": {
+              "value": "{100%.brand.jupiter.400}",
+              "type": "color"
+            },
+            "uranus": {
+              "value": "{100%.brand.uranus.400}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.400}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.400}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.300}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.300}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.300}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.300}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.300}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.300}",
+              "type": "color"
+            }
+          }
+        },
+        "icon": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.50}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.100}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.300}",
+              "type": "color"
+            },
+            "pure-inv": {
+              "value": "{100%.grey.900}",
+              "type": "color"
+            },
+            "brand-inv": {
+              "value": "{100%.grey.800}",
+              "type": "color"
+            },
+            "muted-inv": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "jupiter": {
+              "value": "{100%.brand.jupiter.400}",
+              "type": "color"
+            },
+            "uranus": {
+              "value": "{100%.brand.uranus.400}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.400}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.400}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.300}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.300}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.300}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.300}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.300}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.300}",
+              "type": "color"
+            }
+          }
+        },
+        "shadow": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.500}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.400}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.300}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "uranus": {
+              "value": "{100%.brand.uranus.400}",
+              "type": "color"
+            },
+            "jupiter": {
+              "value": "{100%.brand.jupiter.400}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.400}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.400}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.400}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.400}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.400}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.400}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.400}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.400}",
+              "type": "color"
+            }
+          }
+        }
+      },
+      "disabled*": {
+        "bg": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.600}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.600}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.600}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "uranus": {
+              "value": "{60%.brand.uranus.900}",
+              "type": "color"
+            },
+            "jupiter": {
+              "value": "{60%.brand.jupiter.900}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{60%.brand.neptune.900}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{60%.brand.saturn.900}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{60%.brand.cosmic.900}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{60%.brand.nebula.900}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{60%.alert.info.900}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{60%.alert.warning.900}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{60%.alert.success.900}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{60%.alert.error.900}",
+              "type": "color"
+            }
+          }
+        },
+        "border": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "jupiter": {
+              "value": "{100%.brand.jupiter.900}",
+              "type": "color"
+            },
+            "uranus": {
+              "value": "{100%.brand.uranus.900}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.900}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.900}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.900}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.900}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.900}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.900}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.900}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.900}",
+              "type": "color"
+            }
+          }
+        },
+        "text": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "jupiter": {
+              "value": "{100%.brand.jupiter.900}",
+              "type": "color"
+            },
+            "uranus": {
+              "value": "{100%.brand.uranus.900}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.900}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.900}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.900}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.900}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.900}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.900}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.900}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.900}",
+              "type": "color"
+            }
+          }
+        },
+        "icon": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "jupiter": {
+              "value": "{100%.brand.jupiter.900}",
+              "type": "color"
+            },
+            "uranus": {
+              "value": "{100%.brand.uranus.900}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.900}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.900}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.900}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.900}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.900}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.900}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.900}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.900}",
+              "type": "color"
+            }
+          }
+        },
+        "shadow": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.600}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.600}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.600}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "uranus": {
+              "value": "{60%.brand.uranus.900}",
+              "type": "color"
+            },
+            "jupiter": {
+              "value": "{60%.brand.jupiter.900}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{60%.brand.neptune.900}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{60%.brand.saturn.900}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{60%.brand.cosmic.900}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{60%.brand.nebula.900}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{60%.alert.info.900}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{60%.alert.warning.900}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{60%.alert.success.900}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{60%.alert.error.900}",
+              "type": "color"
+            }
+          }
+        }
+      },
+      "active*": {
+        "bg": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.800}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.600}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "uranus": {
+              "value": "{100%.brand.uranus.700}",
+              "type": "color"
+            },
+            "jupiter": {
+              "value": "{100%.brand.jupiter.700}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.700}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.700}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.500}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.400}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.700}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.700}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.700}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.700}",
+              "type": "color"
+            }
+          }
+        },
+        "border": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.50}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.50}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.50}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "jupiter": {
+              "value": "{100%.brand.jupiter.100}",
+              "type": "color"
+            },
+            "uranus": {
+              "value": "{100%.brand.uranus.100}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.100}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.100}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.100}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.100}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.100}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.100}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.100}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.100}",
+              "type": "color"
+            }
+          }
+        },
+        "text": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.50}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.50}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.50}",
+              "type": "color"
+            },
+            "pure-inv": {
+              "value": "{100%.grey.900}",
+              "type": "color"
+            },
+            "brand-inv": {
+              "value": "{100%.grey.800}",
+              "type": "color"
+            },
+            "muted-inv": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "jupiter": {
+              "value": "{100%.brand.jupiter.400}",
+              "type": "color"
+            },
+            "uranus": {
+              "value": "{100%.brand.uranus.400}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.400}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.400}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.300}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.300}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.300}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.300}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.300}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.300}",
+              "type": "color"
+            }
+          }
+        },
+        "icon": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.50}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.100}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.300}",
+              "type": "color"
+            },
+            "pure-inv": {
+              "value": "{100%.grey.900}",
+              "type": "color"
+            },
+            "brand-inv": {
+              "value": "{100%.grey.800}",
+              "type": "color"
+            },
+            "muted-inv": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "jupiter": {
+              "value": "{100%.brand.jupiter.400}",
+              "type": "color"
+            },
+            "uranus": {
+              "value": "{100%.brand.uranus.400}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.400}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.400}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.300}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.300}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.300}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.300}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.300}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.300}",
+              "type": "color"
+            }
+          }
+        },
+        "shadow": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.500}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.400}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.300}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "uranus": {
+              "value": "{100%.brand.uranus.400}",
+              "type": "color"
+            },
+            "jupiter": {
+              "value": "{100%.brand.jupiter.400}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.400}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.400}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.400}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.400}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.400}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.400}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.400}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.400}",
+              "type": "color"
+            }
+          }
+        }
+      },
+      "visited*": {
+        "bg": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.800}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.600}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "uranus": {
+              "value": "{100%.brand.uranus.700}",
+              "type": "color"
+            },
+            "jupiter": {
+              "value": "{100%.brand.jupiter.700}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.700}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.700}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.500}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.400}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.700}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.700}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.700}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.700}",
+              "type": "color"
+            }
+          }
+        },
+        "border": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.50}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.50}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.50}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "jupiter": {
+              "value": "{100%.brand.jupiter.100}",
+              "type": "color"
+            },
+            "uranus": {
+              "value": "{100%.brand.uranus.100}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.100}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.100}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.100}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.100}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.100}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.100}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.100}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.100}",
+              "type": "color"
+            }
+          }
+        },
+        "text": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.50}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.50}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.50}",
+              "type": "color"
+            },
+            "pure-inv": {
+              "value": "{100%.grey.900}",
+              "type": "color"
+            },
+            "brand-inv": {
+              "value": "{100%.grey.800}",
+              "type": "color"
+            },
+            "muted-inv": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "jupiter": {
+              "value": "{100%.brand.jupiter.400}",
+              "type": "color"
+            },
+            "uranus": {
+              "value": "{100%.brand.uranus.400}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.400}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.400}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.300}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.300}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.300}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.300}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.300}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.300}",
+              "type": "color"
+            }
+          }
+        },
+        "icon": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.50}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.100}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.300}",
+              "type": "color"
+            },
+            "pure-inv": {
+              "value": "{100%.grey.900}",
+              "type": "color"
+            },
+            "brand-inv": {
+              "value": "{100%.grey.800}",
+              "type": "color"
+            },
+            "muted-inv": {
+              "value": "{100%.grey.700}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "jupiter": {
+              "value": "{100%.brand.jupiter.400}",
+              "type": "color"
+            },
+            "uranus": {
+              "value": "{100%.brand.uranus.400}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.400}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.400}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.300}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.300}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.300}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.300}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.300}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.300}",
+              "type": "color"
+            }
+          }
+        },
+        "shadow": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.500}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.400}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.300}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "uranus": {
+              "value": "{100%.brand.uranus.400}",
+              "type": "color"
+            },
+            "jupiter": {
+              "value": "{100%.brand.jupiter.400}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.400}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.400}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.400}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.400}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.400}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.400}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.400}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.400}",
+              "type": "color"
+            }
+          }
+        }
+      },
+      "00": {
+        "value": "#ffffff",
+        "type": "color"
+      }
+    },
+    "contrast-shades": {
+      "grey": {
+        "grey-low": {
+          "value": "{100%.grey.400}",
+          "type": "color"
+        },
+        "grey-med-low": {
+          "value": "{100%.grey.300}",
+          "type": "color"
+        },
+        "grey-med-high": {
+          "value": "{100%.grey.200}",
+          "type": "color"
+        },
+        "grey-high": {
+          "value": "{100%.grey.100}",
+          "type": "color"
+        }
+      },
+      "brand": {
+        "jupiter-medium": {
+          "value": "{100%.brand.jupiter.500}",
+          "type": "color"
+        },
+        "jupiter-high": {
+          "value": "{100%.brand.jupiter.400}",
+          "type": "color"
+        },
+        "jupiter-low": {
+          "value": "{100%.brand.jupiter.900}",
+          "type": "color"
+        },
+        "uranus-low": {
+          "value": "{100%.brand.uranus.600}",
+          "type": "color"
+        },
+        "uranus-medium": {
+          "value": "{100%.brand.uranus.500}",
+          "type": "color"
+        },
+        "uranus-high": {
+          "value": "{100%.brand.uranus.300}",
+          "type": "color"
+        },
+        "neptune-low": {
+          "value": "{100%.brand.neptune.300}",
+          "type": "color"
+        },
+        "neptune-medium": {
+          "value": "{100%.brand.neptune.200}",
+          "type": "color"
+        },
+        "neptune-high": {
+          "value": "{100%.brand.neptune.100}",
+          "type": "color"
+        },
+        "saturn-low": {
+          "value": "{100%.brand.saturn.500}",
+          "type": "color"
+        },
+        "saturn-medium": {
+          "value": "{100%.brand.saturn.300}",
+          "type": "color"
+        },
+        "saturn-high": {
+          "value": "{100%.brand.saturn.200}",
+          "type": "color"
+        },
+        "cosmic-low": {
+          "value": "{100%.brand.cosmic.300}",
+          "type": "color"
+        },
+        "cosmic-medium": {
+          "value": "{100%.brand.cosmic.200}",
+          "type": "color"
+        },
+        "cosmic-high": {
+          "value": "{100%.brand.cosmic.100}",
+          "type": "color"
+        },
+        "nebula-low": {
+          "value": "{100%.brand.nebula.300}",
+          "type": "color"
+        },
+        "nebula-medium": {
+          "value": "{100%.brand.nebula.200}",
+          "type": "color"
+        },
+        "nebula-high": {
+          "value": "{100%.brand.nebula.100}",
+          "type": "color"
+        }
+      },
+      "alert": {
+        "success-low": {
+          "value": "{100%.alert.success.500}",
+          "type": "color"
+        },
+        "success-medium": {
+          "value": "{100%.alert.success.300}",
+          "type": "color"
+        },
+        "success-high": {
+          "value": "{100%.alert.success.200}",
+          "type": "color"
+        },
+        "info-low": {
+          "value": "{100%.alert.info.500}",
+          "type": "color"
+        },
+        "info-medium": {
+          "value": "{100%.alert.info.300}",
+          "type": "color"
+        },
+        "info-high": {
+          "value": "{100%.alert.info.200}",
+          "type": "color"
+        },
+        "warning-low": {
+          "value": "{100%.alert.warning.500}",
+          "type": "color"
+        },
+        "warning-medium": {
+          "value": "{100%.alert.warning.300}",
+          "type": "color"
+        },
+        "warning-high": {
+          "value": "{100%.alert.warning.200}",
+          "type": "color"
+        },
+        "error-low": {
+          "value": "{100%.alert.error.300}",
+          "type": "color"
+        },
+        "error-medium": {
+          "value": "{100%.alert.error.200}",
+          "type": "color"
+        },
+        "error-high": {
+          "value": "{100%.alert.error.100}",
+          "type": "color"
+        }
+      }
+    },
+    "is-dark-mode": {
+      "value": "true",
+      "type": "boolean"
+    },
+    "is-light-mode": {
+      "value": "false",
+      "type": "boolean"
+    }
+  },
+  "color-theme/light-mode": {
+    "status": {
+      "default": {
+        "surface": {
+          "btn": {
+            "brand": {
+              "primary": {
+                "value": "{100%.brand.nebula.700}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{25%.brand.nebula.300}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{0%.transparent}",
+                "type": "color"
+              }
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.700}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{25%.grey.300}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{0%.transparent}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.alert.success.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.alert.success.300}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.alert.success.100}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.alert.info.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.alert.info.300}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.alert.info.100}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.alert.warning.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.alert.warning.300}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.alert.warning.100}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.alert.error.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.alert.error.300}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.alert.error.100}",
+                  "type": "color"
+                }
+              }
+            }
+          },
+          "interactive": {
+            "brand": {
+              "primary": {
+                "value": "{100%.brand.nebula.700}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{25%.brand.nebula.300}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{0%.transparent}",
+                "type": "color"
+              }
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.700}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{25%.grey.300}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{0%.transparent}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.alert.success.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.alert.success.300}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.alert.success.100}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.alert.info.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.alert.info.300}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.alert.info.100}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.alert.warning.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.alert.warning.300}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.alert.warning.100}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.alert.error.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.alert.error.300}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.alert.error.100}",
+                  "type": "color"
+                }
+              }
+            }
+          }
+        },
+        "indicator": {
+          "indicate": {
+            "value": "#ffffff",
+            "type": "color"
+          },
+          "border": {
+            "btn": {
+              "brand": {
+                "primary": {
+                  "value": "{100%.brand.nebula.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.brand.nebula.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              },
+              "grey": {
+                "primary": {
+                  "value": "{100%.grey.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.grey.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              },
+              "alert": {
+                "success": {
+                  "primary": {
+                    "value": "{100%.alert.success.800}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.success.700}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{0%.transparent}",
+                    "type": "color"
+                  }
+                },
+                "info": {
+                  "primary": {
+                    "value": "{100%.alert.info.700}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.info.700}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{0%.transparent}",
+                    "type": "color"
+                  }
+                },
+                "warning": {
+                  "primary": {
+                    "value": "{100%.alert.warning.800}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.warning.700}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{0%.transparent}",
+                    "type": "color"
+                  }
+                },
+                "error": {
+                  "primary": {
+                    "value": "{100%.alert.error.800}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.error.700}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{0%.transparent}",
+                    "type": "color"
+                  }
+                }
+              }
+            },
+            "interactive": {
+              "brand": {
+                "primary": {
+                  "value": "{100%.brand.nebula.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.brand.nebula.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              },
+              "grey": {
+                "primary": {
+                  "value": "{100%.grey.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.grey.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              },
+              "alert": {
+                "success": {
+                  "primary": {
+                    "value": "{100%.alert.success.800}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.success.700}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{0%.transparent}",
+                    "type": "color"
+                  }
+                },
+                "info": {
+                  "primary": {
+                    "value": "{100%.alert.info.700}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.info.700}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{0%.transparent}",
+                    "type": "color"
+                  }
+                },
+                "warning": {
+                  "primary": {
+                    "value": "{100%.alert.warning.800}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.warning.700}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{0%.transparent}",
+                    "type": "color"
+                  }
+                },
+                "error": {
+                  "primary": {
+                    "value": "{100%.alert.error.800}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.error.700}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{0%.transparent}",
+                    "type": "color"
+                  }
+                }
+              }
+            }
+          },
+          "surface": {
+            "btn": {
+              "brand": {
+                "primary": {
+                  "value": "{100%.brand.nebula.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.brand.nebula.300}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.brand.nebula.100}",
+                  "type": "color"
+                }
+              },
+              "grey": {
+                "primary": {
+                  "value": "{100%.grey.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.grey.300}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{5%.grey.600}",
+                  "type": "color"
+                }
+              },
+              "alert": {
+                "success": {
+                  "primary": {
+                    "value": "{100%.alert.success.700}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{25%.alert.success.300}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{25%.alert.success.300}",
+                    "type": "color"
+                  }
+                },
+                "info": {
+                  "primary": {
+                    "value": "{100%.alert.info.700}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{25%.alert.info.300}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{25%.alert.info.300}",
+                    "type": "color"
+                  }
+                },
+                "warning": {
+                  "primary": {
+                    "value": "{100%.alert.warning.700}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{25%.alert.warning.300}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{25%.alert.warning.300}",
+                    "type": "color"
+                  }
+                },
+                "error": {
+                  "primary": {
+                    "value": "{100%.alert.error.700}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{25%.alert.error.300}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{25%.alert.error.300}",
+                    "type": "color"
+                  }
+                }
+              }
+            },
+            "interactive": {
+              "brand": {
+                "primary": {
+                  "value": "{100%.brand.nebula.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.brand.nebula.300}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.brand.nebula.100}",
+                  "type": "color"
+                }
+              },
+              "grey": {
+                "primary": {
+                  "value": "{100%.grey.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.grey.300}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{5%.grey.600}",
+                  "type": "color"
+                }
+              },
+              "alert": {
+                "success": {
+                  "primary": {
+                    "value": "{100%.alert.success.700}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{25%.alert.success.300}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{25%.alert.success.300}",
+                    "type": "color"
+                  }
+                },
+                "info": {
+                  "primary": {
+                    "value": "{100%.alert.info.700}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{25%.alert.info.300}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{25%.alert.info.300}",
+                    "type": "color"
+                  }
+                },
+                "warning": {
+                  "primary": {
+                    "value": "{100%.alert.warning.700}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{25%.alert.warning.300}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{25%.alert.warning.300}",
+                    "type": "color"
+                  }
+                },
+                "error": {
+                  "primary": {
+                    "value": "{100%.alert.error.700}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{25%.alert.error.300}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{25%.alert.error.300}",
+                    "type": "color"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "content": {
+          "btn": {
+            "brand": {
+              "primary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.700}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.brand.nebula.800}",
+                "type": "color"
+              }
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.700}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.grey.800}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.success.800}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.info.800}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.warning.800}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.error.800}",
+                  "type": "color"
+                }
+              }
+            }
+          },
+          "interactive": {
+            "brand": {
+              "primary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.700}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.brand.nebula.800}",
+                "type": "color"
+              }
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.700}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.grey.800}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.success.800}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.info.800}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.warning.800}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.error.800}",
+                  "type": "color"
+                }
+              }
+            }
+          }
+        },
+        "border": {
+          "btn": {
+            "brand": {
+              "primary": {
+                "value": "{100%.brand.nebula.800}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.700}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{0%.transparent}",
+                "type": "color"
+              }
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.800}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.700}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{0%.transparent}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.alert.success.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.alert.info.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.alert.warning.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.alert.error.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              }
+            }
+          },
+          "interactive": {
+            "brand": {
+              "primary": {
+                "value": "{100%.brand.nebula.800}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.700}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{0%.transparent}",
+                "type": "color"
+              }
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.800}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.700}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{0%.transparent}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.alert.success.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.alert.info.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.alert.warning.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.alert.error.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              }
+            }
+          }
+        }
+      },
+      "disabled": {
+        "surface": {
+          "btn": {
+            "brand": {
+              "value": "{100%.grey.100}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.brand.nebula.700}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{25%.brand.nebula.300}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{25%.brand.nebula.300}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.200}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.700}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{25%.grey.300}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{25%.grey.300}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.alert.success.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.alert.success.300}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.alert.success.300}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.alert.info.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.alert.info.300}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.alert.info.300}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.alert.warning.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.alert.warning.300}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.alert.warning.300}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.alert.error.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.alert.error.300}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.alert.error.300}",
+                  "type": "color"
+                }
+              }
+            }
+          },
+          "interactive": {
+            "brand": {
+              "value": "{100%.grey.100}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.brand.nebula.700}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{25%.brand.nebula.300}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{25%.brand.nebula.300}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.200}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.700}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{25%.grey.300}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{25%.grey.300}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.alert.success.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.alert.success.300}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.alert.success.300}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.alert.info.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.alert.info.300}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.alert.info.300}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.alert.warning.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.alert.warning.300}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.alert.warning.300}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.alert.error.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.alert.error.300}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.alert.error.300}",
+                  "type": "color"
+                }
+              }
+            }
+          }
+        },
+        "border": {
+          "btn": {
+            "brand": {
+              "value": "{100%.grey.100}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.brand.nebula.800}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.700}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{0%.transparent}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.200}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.800}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.700}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{0%.transparent}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.alert.success.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.alert.info.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.alert.warning.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.alert.error.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              }
+            }
+          },
+          "interactive": {
+            "brand": {
+              "value": "{100%.grey.100}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.brand.nebula.800}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.700}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{0%.transparent}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.200}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.800}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.700}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{0%.transparent}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.alert.success.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.alert.info.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.alert.warning.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.alert.error.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              }
+            }
+          }
+        },
+        "content": {
+          "btn": {
+            "brand": {
+              "value": "{100%.grey.100}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.700}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.brand.nebula.800}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.200}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.700}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.grey.800}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.success.400}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.info.800}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.warning.800}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.error.800}",
+                  "type": "color"
+                }
+              }
+            }
+          },
+          "interactive": {
+            "brand": {
+              "value": "{100%.grey.100}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.700}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.brand.nebula.800}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.200}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.700}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.grey.800}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.success.400}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.info.800}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.warning.800}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.error.800}",
+                  "type": "color"
+                }
+              }
+            }
+          }
+        },
+        "indicator": {
+          "indicate": {
+            "value": "#ffffff",
+            "type": "color"
+          },
+          "surface": {
+            "btn": {
+              "brand": {
+                "value": "{100%.grey.100}",
+                "type": "color",
+                "primary": {
+                  "value": "{100%.brand.nebula.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.brand.nebula.300}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.brand.nebula.300}",
+                  "type": "color"
+                }
+              },
+              "muted": {
+                "value": "{100%.grey.200}",
+                "type": "color"
+              },
+              "grey": {
+                "primary": {
+                  "value": "{100%.grey.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.grey.300}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.grey.300}",
+                  "type": "color"
+                }
+              },
+              "alert": {
+                "success": {
+                  "primary": {
+                    "value": "{100%.alert.success.700}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{25%.alert.success.300}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{25%.alert.success.300}",
+                    "type": "color"
+                  }
+                },
+                "info": {
+                  "primary": {
+                    "value": "{100%.alert.info.700}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{25%.alert.info.300}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{25%.alert.info.300}",
+                    "type": "color"
+                  }
+                },
+                "warning": {
+                  "primary": {
+                    "value": "{100%.alert.warning.700}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{25%.alert.warning.300}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{25%.alert.warning.300}",
+                    "type": "color"
+                  }
+                },
+                "error": {
+                  "primary": {
+                    "value": "{100%.alert.error.700}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{25%.alert.error.300}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{25%.alert.error.300}",
+                    "type": "color"
+                  }
+                }
+              }
+            },
+            "interactive": {
+              "brand": {
+                "value": "{100%.grey.100}",
+                "type": "color",
+                "primary": {
+                  "value": "{100%.brand.nebula.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.brand.nebula.300}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.brand.nebula.300}",
+                  "type": "color"
+                }
+              },
+              "muted": {
+                "value": "{100%.grey.200}",
+                "type": "color"
+              },
+              "grey": {
+                "primary": {
+                  "value": "{100%.grey.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{25%.grey.300}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.grey.300}",
+                  "type": "color"
+                }
+              },
+              "alert": {
+                "success": {
+                  "primary": {
+                    "value": "{100%.alert.success.700}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{25%.alert.success.300}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{25%.alert.success.300}",
+                    "type": "color"
+                  }
+                },
+                "info": {
+                  "primary": {
+                    "value": "{100%.alert.info.700}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{25%.alert.info.300}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{25%.alert.info.300}",
+                    "type": "color"
+                  }
+                },
+                "warning": {
+                  "primary": {
+                    "value": "{100%.alert.warning.700}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{25%.alert.warning.300}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{25%.alert.warning.300}",
+                    "type": "color"
+                  }
+                },
+                "error": {
+                  "primary": {
+                    "value": "{100%.alert.error.700}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{25%.alert.error.300}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{25%.alert.error.300}",
+                    "type": "color"
+                  }
+                }
+              }
+            }
+          },
+          "border": {
+            "btn": {
+              "brand": {
+                "value": "{100%.grey.100}",
+                "type": "color",
+                "primary": {
+                  "value": "{100%.brand.nebula.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.brand.nebula.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              },
+              "muted": {
+                "value": "{100%.grey.200}",
+                "type": "color"
+              },
+              "grey": {
+                "primary": {
+                  "value": "{100%.grey.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.grey.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              },
+              "alert": {
+                "success": {
+                  "primary": {
+                    "value": "{100%.alert.success.800}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.success.700}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{0%.transparent}",
+                    "type": "color"
+                  }
+                },
+                "info": {
+                  "primary": {
+                    "value": "{100%.alert.info.700}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.info.700}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{0%.transparent}",
+                    "type": "color"
+                  }
+                },
+                "warning": {
+                  "primary": {
+                    "value": "{100%.alert.warning.800}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.warning.700}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{0%.transparent}",
+                    "type": "color"
+                  }
+                },
+                "error": {
+                  "primary": {
+                    "value": "{100%.alert.error.800}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.error.700}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{0%.transparent}",
+                    "type": "color"
+                  }
+                }
+              }
+            },
+            "interactive": {
+              "brand": {
+                "value": "{100%.grey.100}",
+                "type": "color",
+                "primary": {
+                  "value": "{100%.brand.nebula.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.brand.nebula.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              },
+              "muted": {
+                "value": "{100%.grey.200}",
+                "type": "color"
+              },
+              "grey": {
+                "primary": {
+                  "value": "{100%.grey.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.grey.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{0%.transparent}",
+                  "type": "color"
+                }
+              },
+              "alert": {
+                "success": {
+                  "primary": {
+                    "value": "{100%.alert.success.800}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.success.700}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{0%.transparent}",
+                    "type": "color"
+                  }
+                },
+                "info": {
+                  "primary": {
+                    "value": "{100%.alert.info.700}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.info.700}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{0%.transparent}",
+                    "type": "color"
+                  }
+                },
+                "warning": {
+                  "primary": {
+                    "value": "{100%.alert.warning.800}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.warning.700}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{0%.transparent}",
+                    "type": "color"
+                  }
+                },
+                "error": {
+                  "primary": {
+                    "value": "{100%.alert.error.800}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.error.700}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{0%.transparent}",
+                    "type": "color"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "hover": {
+        "surface": {
+          "btn": {
+            "brand": {
+              "value": "{100%.grey.100}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.brand.nebula.900}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{40%.brand.nebula.300}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{25%.brand.nebula.300}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.200}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.900}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{40%.grey.300}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{40%.grey.300}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.alert.success.900}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{40%.alert.success.300}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{40%.alert.success.300}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.alert.info.900}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{40%.alert.info.300}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{40%.alert.info.300}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.alert.warning.900}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{40%.alert.warning.300}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{40%.alert.warning.300}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.alert.error.900}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{40%.alert.error.300}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{40%.alert.error.300}",
+                  "type": "color"
+                }
+              }
+            }
+          },
+          "interactive": {
+            "brand": {
+              "value": "{100%.grey.100}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.brand.nebula.900}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{40%.brand.nebula.300}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{25%.brand.nebula.300}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.200}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.900}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{40%.grey.300}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{40%.grey.300}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.alert.success.900}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{40%.alert.success.300}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{40%.alert.success.300}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.alert.info.900}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{40%.alert.info.300}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{40%.alert.info.300}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.alert.warning.900}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{40%.alert.warning.300}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{40%.alert.warning.300}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.alert.error.900}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{40%.alert.error.300}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{40%.alert.error.300}",
+                  "type": "color"
+                }
+              }
+            }
+          }
+        },
+        "border": {
+          "btn": {
+            "brand": {
+              "value": "{100%.grey.100}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.brand.nebula.700}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.900}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.brand.nebula.900}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.200}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.700}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.900}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.grey.900}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.alert.success.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.success.900}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.alert.info.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.info.900}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.alert.warning.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.warning.900}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.alert.error.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.error.900}",
+                  "type": "color"
+                }
+              }
+            }
+          },
+          "interactive": {
+            "brand": {
+              "value": "{100%.grey.100}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.brand.nebula.700}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.900}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.brand.nebula.900}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.200}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.700}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.900}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.grey.900}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.alert.success.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.success.900}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.alert.info.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.info.900}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.alert.warning.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.warning.900}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.alert.error.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.error.900}",
+                  "type": "color"
+                }
+              }
+            }
+          }
+        },
+        "content": {
+          "btn": {
+            "brand": {
+              "value": "{100%.grey.100}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.900}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.brand.nebula.900}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.200}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.900}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.grey.900}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.success.900}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.info.900}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.warning.900}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.error.900}",
+                  "type": "color"
+                }
+              }
+            }
+          },
+          "interactive": {
+            "brand": {
+              "value": "{100%.grey.100}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.900}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.brand.nebula.900}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.200}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.900}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.grey.900}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.success.900}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.info.900}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.warning.900}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.error.900}",
+                  "type": "color"
+                }
+              }
+            }
+          }
+        },
+        "indicator": {
+          "indicate": {
+            "value": "#ffffff",
+            "type": "color"
+          },
+          "surface": {
+            "btn": {
+              "brand": {
+                "value": "{100%.grey.100}",
+                "type": "color",
+                "primary": {
+                  "value": "{100%.brand.nebula.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{40%.brand.nebula.300}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.brand.nebula.300}",
+                  "type": "color"
+                }
+              },
+              "muted": {
+                "value": "{100%.grey.200}",
+                "type": "color"
+              },
+              "grey": {
+                "primary": {
+                  "value": "{100%.grey.900}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{40%.grey.300}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{40%.grey.300}",
+                  "type": "color"
+                }
+              },
+              "alert": {
+                "success": {
+                  "primary": {
+                    "value": "{100%.alert.success.900}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{40%.alert.success.300}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{40%.alert.success.300}",
+                    "type": "color"
+                  }
+                },
+                "info": {
+                  "primary": {
+                    "value": "{100%.alert.info.900}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{40%.alert.info.300}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{40%.alert.info.300}",
+                    "type": "color"
+                  }
+                },
+                "warning": {
+                  "primary": {
+                    "value": "{100%.alert.warning.900}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{40%.alert.warning.300}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{40%.alert.warning.300}",
+                    "type": "color"
+                  }
+                },
+                "error": {
+                  "primary": {
+                    "value": "{100%.alert.error.900}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{40%.alert.error.300}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{40%.alert.error.300}",
+                    "type": "color"
+                  }
+                }
+              }
+            },
+            "interactive": {
+              "brand": {
+                "value": "{100%.grey.100}",
+                "type": "color",
+                "primary": {
+                  "value": "{100%.brand.nebula.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{40%.brand.nebula.300}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{25%.brand.nebula.300}",
+                  "type": "color"
+                }
+              },
+              "muted": {
+                "value": "{100%.grey.200}",
+                "type": "color"
+              },
+              "grey": {
+                "primary": {
+                  "value": "{100%.grey.900}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{40%.grey.300}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{40%.grey.300}",
+                  "type": "color"
+                }
+              },
+              "alert": {
+                "success": {
+                  "primary": {
+                    "value": "{100%.alert.success.900}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{40%.alert.success.300}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{40%.alert.success.300}",
+                    "type": "color"
+                  }
+                },
+                "info": {
+                  "primary": {
+                    "value": "{100%.alert.info.900}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{40%.alert.info.300}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{40%.alert.info.300}",
+                    "type": "color"
+                  }
+                },
+                "warning": {
+                  "primary": {
+                    "value": "{100%.alert.warning.900}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{40%.alert.warning.300}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{40%.alert.warning.300}",
+                    "type": "color"
+                  }
+                },
+                "error": {
+                  "primary": {
+                    "value": "{100%.alert.error.900}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{40%.alert.error.300}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{40%.alert.error.300}",
+                    "type": "color"
+                  }
+                }
+              }
+            }
+          },
+          "border": {
+            "btn": {
+              "brand": {
+                "value": "{100%.grey.100}",
+                "type": "color",
+                "primary": {
+                  "value": "{100%.brand.nebula.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.brand.nebula.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.brand.nebula.900}",
+                  "type": "color"
+                }
+              },
+              "muted": {
+                "value": "{100%.grey.200}",
+                "type": "color"
+              },
+              "grey": {
+                "primary": {
+                  "value": "{100%.grey.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.grey.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.grey.900}",
+                  "type": "color"
+                }
+              },
+              "alert": {
+                "success": {
+                  "primary": {
+                    "value": "{100%.alert.success.700}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.success.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.success.900}",
+                    "type": "color"
+                  }
+                },
+                "info": {
+                  "primary": {
+                    "value": "{100%.alert.info.700}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.info.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.info.900}",
+                    "type": "color"
+                  }
+                },
+                "warning": {
+                  "primary": {
+                    "value": "{100%.alert.warning.700}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.warning.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.warning.900}",
+                    "type": "color"
+                  }
+                },
+                "error": {
+                  "primary": {
+                    "value": "{100%.alert.error.700}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.error.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.error.900}",
+                    "type": "color"
+                  }
+                }
+              }
+            },
+            "interactive": {
+              "brand": {
+                "value": "{100%.grey.100}",
+                "type": "color",
+                "primary": {
+                  "value": "{100%.brand.nebula.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.brand.nebula.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.brand.nebula.900}",
+                  "type": "color"
+                }
+              },
+              "muted": {
+                "value": "{100%.grey.200}",
+                "type": "color"
+              },
+              "grey": {
+                "primary": {
+                  "value": "{100%.grey.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.grey.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.grey.900}",
+                  "type": "color"
+                }
+              },
+              "alert": {
+                "success": {
+                  "primary": {
+                    "value": "{100%.alert.success.700}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.success.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.success.900}",
+                    "type": "color"
+                  }
+                },
+                "info": {
+                  "primary": {
+                    "value": "{100%.alert.info.700}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.info.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.info.900}",
+                    "type": "color"
+                  }
+                },
+                "warning": {
+                  "primary": {
+                    "value": "{100%.alert.warning.700}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.warning.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.warning.900}",
+                    "type": "color"
+                  }
+                },
+                "error": {
+                  "primary": {
+                    "value": "{100%.alert.error.700}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.error.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.error.900}",
+                    "type": "color"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "focus": {
+        "surface": {
+          "btn": {
+            "brand": {
+              "value": "{100%.grey.100}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.brand.nebula.700}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{60%.brand.nebula.100}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{60%.brand.nebula.100}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.200}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.700}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{60%.grey.100}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{60%.grey.100}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.alert.success.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{60%.alert.success.100}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{60%.alert.success.100}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.alert.info.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{60%.alert.info.100}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{60%.alert.info.100}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.alert.warning.900}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{60%.alert.warning.100}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{60%.alert.warning.100}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.alert.error.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{60%.alert.error.100}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{60%.alert.error.100}",
+                  "type": "color"
+                }
+              }
+            }
+          },
+          "interactive": {
+            "brand": {
+              "value": "{100%.grey.100}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.brand.nebula.700}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{60%.brand.nebula.100}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{60%.brand.nebula.100}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.200}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.700}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{60%.grey.100}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{60%.grey.100}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.alert.success.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{60%.alert.success.100}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{60%.alert.success.100}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.alert.info.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{60%.alert.info.100}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{60%.alert.info.100}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.alert.warning.900}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{60%.alert.warning.100}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{60%.alert.warning.100}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.alert.error.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{60%.alert.error.100}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{60%.alert.error.100}",
+                  "type": "color"
+                }
+              }
+            }
+          }
+        },
+        "border": {
+          "btn": {
+            "brand": {
+              "value": "{100%.grey.100}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.brand.nebula.900}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.900}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.brand.nebula.900}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.200}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.900}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.900}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.grey.900}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.alert.success.900}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.success.900}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.alert.info.900}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.info.900}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.alert.warning.900}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.warning.900}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.alert.error.900}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.error.900}",
+                  "type": "color"
+                }
+              }
+            }
+          },
+          "interactive": {
+            "brand": {
+              "value": "{100%.grey.100}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.brand.nebula.900}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.900}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.brand.nebula.900}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.200}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.900}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.900}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.grey.900}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.alert.success.900}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.success.900}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.alert.info.900}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.info.900}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.alert.warning.900}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.warning.900}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.alert.error.900}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.error.900}",
+                  "type": "color"
+                }
+              }
+            }
+          }
+        },
+        "content": {
+          "btn": {
+            "brand": {
+              "value": "{100%.grey.100}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.900}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.brand.nebula.900}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.200}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.900}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.grey.900}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.success.900}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.info.900}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.warning.900}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.error.900}",
+                  "type": "color"
+                }
+              }
+            }
+          },
+          "interactive": {
+            "brand": {
+              "value": "{100%.grey.100}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.900}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.brand.nebula.900}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.200}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.900}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.grey.900}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.success.900}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.info.900}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.warning.900}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.error.900}",
+                  "type": "color"
+                }
+              }
+            }
+          }
+        },
+        "indicator": {
+          "indicate": {
+            "value": "#ffffff",
+            "type": "color"
+          },
+          "border": {
+            "btn": {
+              "brand": {
+                "value": "{100%.grey.100}",
+                "type": "color",
+                "primary": {
+                  "value": "{100%.brand.nebula.900}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.brand.nebula.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.brand.nebula.900}",
+                  "type": "color"
+                }
+              },
+              "muted": {
+                "value": "{100%.grey.200}",
+                "type": "color"
+              },
+              "grey": {
+                "primary": {
+                  "value": "{100%.grey.900}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.grey.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.grey.900}",
+                  "type": "color"
+                }
+              },
+              "alert": {
+                "success": {
+                  "primary": {
+                    "value": "{100%.alert.success.900}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.success.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.success.900}",
+                    "type": "color"
+                  }
+                },
+                "info": {
+                  "primary": {
+                    "value": "{100%.alert.info.900}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.info.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.info.900}",
+                    "type": "color"
+                  }
+                },
+                "warning": {
+                  "primary": {
+                    "value": "{100%.alert.warning.900}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.warning.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.warning.900}",
+                    "type": "color"
+                  }
+                },
+                "error": {
+                  "primary": {
+                    "value": "{100%.alert.error.900}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.error.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.error.900}",
+                    "type": "color"
+                  }
+                }
+              }
+            },
+            "interactive": {
+              "brand": {
+                "value": "{100%.grey.100}",
+                "type": "color",
+                "primary": {
+                  "value": "{100%.brand.nebula.900}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.brand.nebula.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.brand.nebula.900}",
+                  "type": "color"
+                }
+              },
+              "muted": {
+                "value": "{100%.grey.200}",
+                "type": "color"
+              },
+              "grey": {
+                "primary": {
+                  "value": "{100%.grey.900}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.grey.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.grey.900}",
+                  "type": "color"
+                }
+              },
+              "alert": {
+                "success": {
+                  "primary": {
+                    "value": "{100%.alert.success.900}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.success.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.success.900}",
+                    "type": "color"
+                  }
+                },
+                "info": {
+                  "primary": {
+                    "value": "{100%.alert.info.900}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.info.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.info.900}",
+                    "type": "color"
+                  }
+                },
+                "warning": {
+                  "primary": {
+                    "value": "{100%.alert.warning.900}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.warning.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.warning.900}",
+                    "type": "color"
+                  }
+                },
+                "error": {
+                  "primary": {
+                    "value": "{100%.alert.error.900}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.error.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.error.900}",
+                    "type": "color"
+                  }
+                }
+              }
+            }
+          },
+          "surface": {
+            "btn": {
+              "brand": {
+                "value": "{100%.grey.100}",
+                "type": "color",
+                "primary": {
+                  "value": "{100%.brand.nebula.300}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{60%.brand.nebula.300}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{60%.brand.nebula.300}",
+                  "type": "color"
+                }
+              },
+              "muted": {
+                "value": "{100%.grey.200}",
+                "type": "color"
+              },
+              "grey": {
+                "primary": {
+                  "value": "{100%.grey.300}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{60%.grey.300}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{60%.grey.300}",
+                  "type": "color"
+                }
+              },
+              "alert": {
+                "success": {
+                  "primary": {
+                    "value": "{100%.alert.success.300}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{60%.alert.success.300}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{60%.alert.success.300}",
+                    "type": "color"
+                  }
+                },
+                "info": {
+                  "primary": {
+                    "value": "{100%.alert.info.300}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{60%.alert.info.300}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{60%.alert.info.300}",
+                    "type": "color"
+                  }
+                },
+                "warning": {
+                  "primary": {
+                    "value": "{100%.alert.warning.300}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{60%.alert.warning.300}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{60%.alert.warning.300}",
+                    "type": "color"
+                  }
+                },
+                "error": {
+                  "primary": {
+                    "value": "{100%.alert.error.300}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{60%.alert.error.300}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{60%.alert.error.300}",
+                    "type": "color"
+                  }
+                }
+              }
+            },
+            "interactive": {
+              "brand": {
+                "value": "{100%.grey.100}",
+                "type": "color",
+                "primary": {
+                  "value": "{100%.brand.nebula.300}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{60%.brand.nebula.300}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{60%.brand.nebula.300}",
+                  "type": "color"
+                }
+              },
+              "muted": {
+                "value": "{100%.grey.200}",
+                "type": "color"
+              },
+              "grey": {
+                "primary": {
+                  "value": "{100%.grey.300}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{60%.grey.300}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{60%.grey.300}",
+                  "type": "color"
+                }
+              },
+              "alert": {
+                "success": {
+                  "primary": {
+                    "value": "{100%.alert.success.300}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{60%.alert.success.300}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{60%.alert.success.300}",
+                    "type": "color"
+                  }
+                },
+                "info": {
+                  "primary": {
+                    "value": "{100%.alert.info.300}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{60%.alert.info.300}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{60%.alert.info.300}",
+                    "type": "color"
+                  }
+                },
+                "warning": {
+                  "primary": {
+                    "value": "{100%.alert.warning.300}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{60%.alert.warning.300}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{60%.alert.warning.300}",
+                    "type": "color"
+                  }
+                },
+                "error": {
+                  "primary": {
+                    "value": "{100%.alert.error.300}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{60%.alert.error.300}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{60%.alert.error.300}",
+                    "type": "color"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "active": {
+        "surface": {
+          "btn": {
+            "brand": {
+              "value": "{100%.grey.100}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.brand.nebula.700}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.100}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.brand.nebula.100}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.200}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.700}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.100}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.grey.100}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.alert.success.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.100}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.success.100}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.alert.info.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.100}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.info.100}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.alert.warning.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.100}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.warning.100}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.alert.error.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.100}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.error.100}",
+                  "type": "color"
+                }
+              }
+            }
+          },
+          "interactive": {
+            "brand": {
+              "value": "{100%.grey.100}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.brand.nebula.700}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.100}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.brand.nebula.100}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.200}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.700}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.100}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.grey.100}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.alert.success.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.100}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.success.100}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.alert.info.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.100}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.info.100}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.alert.warning.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.100}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.warning.100}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.alert.error.700}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.100}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.error.100}",
+                  "type": "color"
+                }
+              }
+            }
+          }
+        },
+        "border": {
+          "btn": {
+            "brand": {
+              "value": "{100%.grey.100}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.brand.nebula.700}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.500}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.brand.nebula.500}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.200}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.800}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.500}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.grey.500}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.alert.success.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.500}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.success.500}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.alert.info.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.500}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.info.500}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.alert.warning.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.500}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.warning.500}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.alert.error.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.500}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.error.500}",
+                  "type": "color"
+                }
+              }
+            }
+          },
+          "interactive": {
+            "brand": {
+              "value": "{100%.grey.100}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.brand.nebula.700}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.500}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.brand.nebula.500}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.200}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.800}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.500}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.grey.500}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.alert.success.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.500}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.success.500}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.alert.info.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.500}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.info.500}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.alert.warning.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.500}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.warning.500}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.alert.error.800}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.500}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.error.500}",
+                  "type": "color"
+                }
+              }
+            }
+          }
+        },
+        "content": {
+          "btn": {
+            "brand": {
+              "value": "{100%.grey.100}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.900}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.brand.nebula.900}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.200}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.900}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.grey.900}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.success.900}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.info.900}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.warning.900}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.error.900}",
+                  "type": "color"
+                }
+              }
+            }
+          },
+          "interactive": {
+            "brand": {
+              "value": "{100%.grey.100}",
+              "type": "color",
+              "primary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.brand.nebula.900}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.brand.nebula.900}",
+                "type": "color"
+              }
+            },
+            "muted": {
+              "value": "{100%.grey.200}",
+              "type": "color"
+            },
+            "grey": {
+              "primary": {
+                "value": "{100%.grey.50}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{100%.grey.900}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{100%.grey.900}",
+                "type": "color"
+              }
+            },
+            "alert": {
+              "success": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.success.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.success.900}",
+                  "type": "color"
+                }
+              },
+              "info": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.info.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.info.900}",
+                  "type": "color"
+                }
+              },
+              "warning": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.warning.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.warning.900}",
+                  "type": "color"
+                }
+              },
+              "error": {
+                "primary": {
+                  "value": "{100%.grey.50}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.alert.error.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.alert.error.900}",
+                  "type": "color"
+                }
+              }
+            }
+          }
+        },
+        "indicator": {
+          "indicate": {
+            "value": "#ffffff",
+            "type": "color"
+          },
+          "surface": {
+            "btn": {
+              "brand": {
+                "primary": {
+                  "value": "{100%.brand.nebula.900}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.brand.nebula.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.brand.nebula.700}",
+                  "type": "color"
+                }
+              },
+              "grey": {
+                "primary": {
+                  "value": "{100%.grey.900}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.grey.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.grey.700}",
+                  "type": "color"
+                }
+              },
+              "alert": {
+                "success": {
+                  "primary": {
+                    "value": "{100%.alert.success.900}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.success.700}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.success.700}",
+                    "type": "color"
+                  }
+                },
+                "info": {
+                  "primary": {
+                    "value": "{100%.alert.info.900}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.info.700}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.info.700}",
+                    "type": "color"
+                  }
+                },
+                "warning": {
+                  "primary": {
+                    "value": "{100%.alert.warning.900}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.warning.700}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.warning.700}",
+                    "type": "color"
+                  }
+                },
+                "error": {
+                  "primary": {
+                    "value": "{100%.alert.error.900}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.error.700}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.error.700}",
+                    "type": "color"
+                  }
+                }
+              }
+            },
+            "interactive": {
+              "brand": {
+                "primary": {
+                  "value": "{100%.brand.nebula.900}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.brand.nebula.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.brand.nebula.700}",
+                  "type": "color"
+                }
+              },
+              "grey": {
+                "primary": {
+                  "value": "{100%.grey.900}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.grey.700}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.grey.700}",
+                  "type": "color"
+                }
+              },
+              "alert": {
+                "success": {
+                  "primary": {
+                    "value": "{100%.alert.success.900}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.success.700}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.success.700}",
+                    "type": "color"
+                  }
+                },
+                "info": {
+                  "primary": {
+                    "value": "{100%.alert.info.900}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.info.700}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.info.700}",
+                    "type": "color"
+                  }
+                },
+                "warning": {
+                  "primary": {
+                    "value": "{100%.alert.warning.900}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.warning.700}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.warning.700}",
+                    "type": "color"
+                  }
+                },
+                "error": {
+                  "primary": {
+                    "value": "{100%.alert.error.900}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.error.700}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.error.700}",
+                    "type": "color"
+                  }
+                }
+              }
+            }
+          },
+          "border": {
+            "btn": {
+              "brand": {
+                "value": "{100%.grey.100}",
+                "type": "color",
+                "primary": {
+                  "value": "{100%.brand.nebula.900}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.brand.nebula.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.brand.nebula.900}",
+                  "type": "color"
+                }
+              },
+              "muted": {
+                "value": "{100%.grey.200}",
+                "type": "color"
+              },
+              "grey": {
+                "primary": {
+                  "value": "{100%.grey.900}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.grey.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.grey.900}",
+                  "type": "color"
+                }
+              },
+              "alert": {
+                "success": {
+                  "primary": {
+                    "value": "{100%.alert.success.900}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.success.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.success.900}",
+                    "type": "color"
+                  }
+                },
+                "info": {
+                  "primary": {
+                    "value": "{100%.alert.info.900}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.info.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.info.900}",
+                    "type": "color"
+                  }
+                },
+                "warning": {
+                  "primary": {
+                    "value": "{100%.alert.warning.900}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.warning.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.warning.900}",
+                    "type": "color"
+                  }
+                },
+                "error": {
+                  "primary": {
+                    "value": "{100%.alert.error.900}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.error.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.error.900}",
+                    "type": "color"
+                  }
+                }
+              }
+            },
+            "interactive": {
+              "brand": {
+                "value": "{100%.grey.100}",
+                "type": "color",
+                "primary": {
+                  "value": "{100%.brand.nebula.900}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.brand.nebula.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.brand.nebula.900}",
+                  "type": "color"
+                }
+              },
+              "muted": {
+                "value": "{100%.grey.200}",
+                "type": "color"
+              },
+              "grey": {
+                "primary": {
+                  "value": "{100%.grey.900}",
+                  "type": "color"
+                },
+                "secondary": {
+                  "value": "{100%.grey.900}",
+                  "type": "color"
+                },
+                "tertiary": {
+                  "value": "{100%.grey.900}",
+                  "type": "color"
+                }
+              },
+              "alert": {
+                "success": {
+                  "primary": {
+                    "value": "{100%.alert.success.900}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.success.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.success.900}",
+                    "type": "color"
+                  }
+                },
+                "info": {
+                  "primary": {
+                    "value": "{100%.alert.info.900}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.info.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.info.900}",
+                    "type": "color"
+                  }
+                },
+                "warning": {
+                  "primary": {
+                    "value": "{100%.alert.warning.900}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.warning.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.warning.900}",
+                    "type": "color"
+                  }
+                },
+                "error": {
+                  "primary": {
+                    "value": "{100%.alert.error.900}",
+                    "type": "color"
+                  },
+                  "secondary": {
+                    "value": "{100%.alert.error.900}",
+                    "type": "color"
+                  },
+                  "tertiary": {
+                    "value": "{100%.alert.error.900}",
+                    "type": "color"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "static": {
+      "core": {
+        "jupiter": {
+          "value": "{100%.brand.jupiter.500}",
+          "type": "color"
+        },
+        "saturn": {
+          "value": "{100%.brand.saturn.500}",
+          "type": "color"
+        },
+        "neptune": {
+          "value": "{100%.brand.neptune.500}",
+          "type": "color"
+        },
+        "uranus": {
+          "value": "{100%.brand.uranus.500}",
+          "type": "color"
+        },
+        "cosmic": {
+          "value": "{100%.brand.cosmic.500}",
+          "type": "color"
+        },
+        "nebula": {
+          "value": "{100%.brand.nebula.500}",
+          "type": "color"
+        }
+      },
+      "surface": {
+        "grey": {
+          "pure": {
+            "value": "{100%.grey.50}",
+            "type": "color"
+          },
+          "brand": {
+            "value": "{100%.grey.100}",
+            "type": "color"
+          },
+          "muted": {
+            "value": "{100%.grey.200}",
+            "type": "color"
+          },
+          "transparent": {
+            "value": "{0%.transparent}",
+            "type": "color"
+          }
+        },
+        "brand": {
+          "uranus": {
+            "value": "{100%.brand.uranus.100}",
+            "type": "color"
+          },
+          "jupiter": {
+            "value": "{100%.brand.jupiter.100}",
+            "type": "color"
+          },
+          "neptune": {
+            "value": "{100%.brand.neptune.100}",
+            "type": "color"
+          },
+          "saturn": {
+            "value": "{100%.brand.saturn.100}",
+            "type": "color"
+          },
+          "cosmic": {
+            "value": "{100%.brand.cosmic.200}",
+            "type": "color"
+          },
+          "nebula": {
+            "value": "{100%.brand.nebula.200}",
+            "type": "color"
+          }
+        },
+        "alert": {
+          "info": {
+            "value": "{100%.alert.info.100}",
+            "type": "color"
+          },
+          "warning": {
+            "value": "{100%.alert.warning.100}",
+            "type": "color"
+          },
+          "success": {
+            "value": "{100%.alert.success.100}",
+            "type": "color"
+          },
+          "error": {
+            "value": "{100%.alert.error.100}",
+            "type": "color"
+          }
+        }
+      },
+      "border": {
+        "grey": {
+          "pure": {
+            "value": "{100%.grey.900}",
+            "type": "color"
+          },
+          "brand": {
+            "value": "{100%.grey.800}",
+            "type": "color"
+          },
+          "muted": {
+            "value": "{100%.grey.600}",
+            "type": "color"
+          }
+        },
+        "brand": {
+          "jupiter": {
+            "value": "{100%.brand.jupiter.700}",
+            "type": "color"
+          },
+          "uranus": {
+            "value": "{100%.brand.uranus.800}",
+            "type": "color"
+          },
+          "neptune": {
+            "value": "{100%.brand.neptune.700}",
+            "type": "color"
+          },
+          "saturn": {
+            "value": "{100%.brand.saturn.800}",
+            "type": "color"
+          },
+          "cosmic": {
+            "value": "{100%.brand.cosmic.500}",
+            "type": "color"
+          },
+          "nebula": {
+            "value": "{100%.brand.nebula.500}",
+            "type": "color"
+          }
+        },
+        "alert": {
+          "info": {
+            "value": "{100%.alert.info.700}",
+            "type": "color"
+          },
+          "warning": {
+            "value": "{100%.alert.warning.800}",
+            "type": "color"
+          },
+          "success": {
+            "value": "{100%.alert.success.600}",
+            "type": "color"
+          },
+          "error": {
+            "value": "{100%.alert.error.600}",
+            "type": "color"
+          }
+        }
+      },
+      "content": {
+        "text": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.900}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.800}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.600}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "jupiter": {
+              "value": "{100%.brand.jupiter.700}",
+              "type": "color"
+            },
+            "uranus": {
+              "value": "{100%.brand.uranus.800}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.700}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.800}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.500}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.500}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.700}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.800}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.600}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.600}",
+              "type": "color"
+            }
+          }
+        },
+        "icon": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.900}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.800}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.600}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "jupiter": {
+              "value": "{100%.brand.jupiter.700}",
+              "type": "color"
+            },
+            "uranus": {
+              "value": "{100%.brand.uranus.800}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.700}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.800}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.500}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.500}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.700}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.800}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.600}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.600}",
+              "type": "color"
+            }
+          }
+        }
+      },
+      "effect": {
+        "shadow": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.200}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.300}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.400}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "uranus": {
+              "value": "{100%.brand.uranus.400}",
+              "type": "color"
+            },
+            "jupiter": {
+              "value": "{100%.brand.jupiter.400}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.400}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.400}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.400}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.400}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.400}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.400}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.400}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.400}",
+              "type": "color"
+            }
+          }
+        },
+        "overlay": {
+          "grey": {
+            "strong": {
+              "value": "{60%.grey.500}",
+              "type": "color"
+            },
+            "base": {
+              "value": "{40%.grey.400}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{25%.grey.300}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "jupiter": {
+              "strong": {
+                "value": "{60%.brand.jupiter.500}",
+                "type": "color"
+              },
+              "base": {
+                "value": "{40%.brand.jupiter.400}",
+                "type": "color"
+              },
+              "muted": {
+                "value": "{25%.brand.jupiter.100}",
+                "type": "color"
+              }
+            },
+            "saturn": {
+              "strong": {
+                "value": "{60%.brand.saturn.500}",
+                "type": "color"
+              },
+              "base": {
+                "value": "{40%.brand.saturn.400}",
+                "type": "color"
+              },
+              "muted": {
+                "value": "{25%.brand.saturn.100}",
+                "type": "color"
+              }
+            },
+            "uranus": {
+              "strong": {
+                "value": "{60%.brand.uranus.500}",
+                "type": "color"
+              },
+              "base": {
+                "value": "{40%.brand.uranus.400}",
+                "type": "color"
+              },
+              "muted": {
+                "value": "{25%.brand.uranus.100}",
+                "type": "color"
+              }
+            },
+            "neptune": {
+              "strong": {
+                "value": "{60%.brand.neptune.500}",
+                "type": "color"
+              },
+              "base": {
+                "value": "{40%.brand.neptune.400}",
+                "type": "color"
+              },
+              "muted": {
+                "value": "{25%.brand.neptune.100}",
+                "type": "color"
+              }
+            },
+            "nebula": {
+              "strong": {
+                "value": "{60%.brand.nebula.500}",
+                "type": "color"
+              },
+              "base": {
+                "value": "{40%.brand.nebula.400}",
+                "type": "color"
+              },
+              "muted": {
+                "value": "{25%.brand.nebula.100}",
+                "type": "color"
+              }
+            },
+            "cosmic": {
+              "strong": {
+                "value": "{60%.brand.cosmic.500}",
+                "type": "color"
+              },
+              "base": {
+                "value": "{40%.brand.cosmic.400}",
+                "type": "color"
+              },
+              "muted": {
+                "value": "{25%.brand.cosmic.100}",
+                "type": "color"
+              }
+            }
+          },
+          "alert": {
+            "success": {
+              "strong": {
+                "value": "{60%.alert.success.500}",
+                "type": "color"
+              },
+              "base": {
+                "value": "{40%.alert.success.400}",
+                "type": "color"
+              },
+              "muted": {
+                "value": "{25%.alert.success.100}",
+                "type": "color"
+              }
+            },
+            "info": {
+              "strong": {
+                "value": "{60%.alert.info.500}",
+                "type": "color"
+              },
+              "base*": {
+                "value": "{40%.alert.info.500}",
+                "type": "color"
+              },
+              "muted": {
+                "value": "{25%.alert.info.100}",
+                "type": "color"
+              }
+            },
+            "warning": {
+              "strong": {
+                "value": "{60%.alert.warning.500}",
+                "type": "color"
+              },
+              "base": {
+                "value": "{40%.alert.warning.400}",
+                "type": "color"
+              },
+              "muted": {
+                "value": "{25%.alert.warning.100}",
+                "type": "color"
+              }
+            },
+            "error": {
+              "strong": {
+                "value": "{60%.alert.error.500}",
+                "type": "color"
+              },
+              "base*": {
+                "value": "{40%.alert.error.500}",
+                "type": "color"
+              },
+              "muted": {
+                "value": "{25%.alert.error.100}",
+                "type": "color"
+              }
+            }
+          }
+        }
+      }
+    },
+    "depreciated": {
+      "hover*": {
+        "bg": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.100}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.200}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.300}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "uranus": {
+              "value": "{100%.brand.saturn.300}",
+              "type": "color"
+            },
+            "jupiter": {
+              "value": "{100%.brand.jupiter.300}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.300}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.300}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.400}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.400}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.300}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.300}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.300}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.300}",
+              "type": "color"
+            }
+          }
+        },
+        "border": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.900}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.900}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.900}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "jupiter": {
+              "value": "{100%.brand.jupiter.900}",
+              "type": "color"
+            },
+            "uranus": {
+              "value": "{100%.brand.uranus.900}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.900}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.900}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.800}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.900}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.800}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.800}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.800}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.800}",
+              "type": "color"
+            }
+          }
+        },
+        "text": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.900}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.900}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.900}",
+              "type": "color"
+            },
+            "pure-inv": {
+              "value": "{100%.grey.50}",
+              "type": "color"
+            },
+            "brand-inv": {
+              "value": "{100%.grey.100}",
+              "type": "color"
+            },
+            "muted-inv": {
+              "value": "{100%.grey.200}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "jupiter": {
+              "value": "{100%.brand.jupiter.700}",
+              "type": "color"
+            },
+            "uranus": {
+              "value": "{100%.brand.uranus.800}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.700}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.800}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.500}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.500}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.700}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.800}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.600}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.600}",
+              "type": "color"
+            }
+          }
+        },
+        "icon": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.900}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.800}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.600}",
+              "type": "color"
+            },
+            "pure-inv": {
+              "value": "{100%.grey.50}",
+              "type": "color"
+            },
+            "brand-inv": {
+              "value": "{100%.grey.100}",
+              "type": "color"
+            },
+            "muted-inv": {
+              "value": "{100%.grey.200}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "jupiter": {
+              "value": "{100%.brand.jupiter.700}",
+              "type": "color"
+            },
+            "uranus": {
+              "value": "{100%.brand.uranus.800}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.700}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.800}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.500}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.500}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.700}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.800}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.600}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.600}",
+              "type": "color"
+            }
+          }
+        },
+        "shadow": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.400}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.500}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.600}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "uranus": {
+              "value": "{100%.brand.uranus.600}",
+              "type": "color"
+            },
+            "jupiter": {
+              "value": "{100%.brand.jupiter.600}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.600}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.600}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.600}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.600}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.600}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.600}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.600}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.600}",
+              "type": "color"
+            }
+          }
+        }
+      },
+      "disabled*": {
+        "bg": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.400}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.400}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.400}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "uranus": {
+              "value": "{100%.brand.uranus.50}",
+              "type": "color"
+            },
+            "jupiter": {
+              "value": "{100%.brand.jupiter.50}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.50}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.50}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.50}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.50}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.50}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.50}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.50}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.50}",
+              "type": "color"
+            }
+          }
+        },
+        "border": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.300}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.300}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.300}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "jupiter": {
+              "value": "{100%.brand.jupiter.200}",
+              "type": "color"
+            },
+            "uranus": {
+              "value": "{100%.brand.uranus.200}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.200}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.200}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.200}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.200}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.200}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.200}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.200}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.200}",
+              "type": "color"
+            }
+          }
+        },
+        "text": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.300}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.300}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.300}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "jupiter": {
+              "value": "{100%.brand.jupiter.200}",
+              "type": "color"
+            },
+            "uranus": {
+              "value": "{100%.brand.uranus.200}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.200}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.200}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.200}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.200}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.200}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.200}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.200}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.200}",
+              "type": "color"
+            }
+          }
+        },
+        "icon": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.300}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.300}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.300}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "jupiter": {
+              "value": "{100%.brand.jupiter.200}",
+              "type": "color"
+            },
+            "uranus": {
+              "value": "{100%.brand.uranus.200}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.200}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.200}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.200}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.200}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.200}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.200}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.200}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.200}",
+              "type": "color"
+            }
+          }
+        },
+        "shadow": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.400}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.400}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.400}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "uranus": {
+              "value": "{100%.brand.uranus.50}",
+              "type": "color"
+            },
+            "jupiter": {
+              "value": "{100%.brand.jupiter.50}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.50}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.50}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.50}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.50}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.50}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.50}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.50}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.50}",
+              "type": "color"
+            }
+          }
+        }
+      },
+      "active*": {
+        "bg": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.100}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.200}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.300}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "uranus": {
+              "value": "{100%.brand.saturn.300}",
+              "type": "color"
+            },
+            "jupiter": {
+              "value": "{100%.brand.jupiter.300}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.300}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.300}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.400}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.400}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.300}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.300}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.300}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.300}",
+              "type": "color"
+            }
+          }
+        },
+        "border": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.900}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.900}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.900}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "jupiter": {
+              "value": "{100%.brand.jupiter.900}",
+              "type": "color"
+            },
+            "uranus": {
+              "value": "{100%.brand.uranus.900}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.900}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.900}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.800}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.900}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.800}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.800}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.800}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.800}",
+              "type": "color"
+            }
+          }
+        },
+        "text": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.900}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.900}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.900}",
+              "type": "color"
+            },
+            "pure-inv": {
+              "value": "{100%.grey.50}",
+              "type": "color"
+            },
+            "brand-inv": {
+              "value": "{100%.grey.100}",
+              "type": "color"
+            },
+            "muted-inv": {
+              "value": "{100%.grey.200}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "jupiter": {
+              "value": "{100%.brand.jupiter.700}",
+              "type": "color"
+            },
+            "uranus": {
+              "value": "{100%.brand.uranus.800}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.700}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.800}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.500}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.500}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.700}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.800}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.600}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.600}",
+              "type": "color"
+            }
+          }
+        },
+        "icon": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.900}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.800}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.600}",
+              "type": "color"
+            },
+            "pure-inv": {
+              "value": "{100%.grey.50}",
+              "type": "color"
+            },
+            "brand-inv": {
+              "value": "{100%.grey.100}",
+              "type": "color"
+            },
+            "muted-inv": {
+              "value": "{100%.grey.200}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "jupiter": {
+              "value": "{100%.brand.jupiter.700}",
+              "type": "color"
+            },
+            "uranus": {
+              "value": "{100%.brand.uranus.800}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.700}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.800}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.500}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.500}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.700}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.800}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.600}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.600}",
+              "type": "color"
+            }
+          }
+        },
+        "shadow": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.400}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.500}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.600}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "uranus": {
+              "value": "{100%.brand.uranus.600}",
+              "type": "color"
+            },
+            "jupiter": {
+              "value": "{100%.brand.jupiter.600}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.600}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.600}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.600}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.600}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.600}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.600}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.600}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.600}",
+              "type": "color"
+            }
+          }
+        }
+      },
+      "visited*": {
+        "bg": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.100}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.200}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.300}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "uranus": {
+              "value": "{100%.brand.saturn.300}",
+              "type": "color"
+            },
+            "jupiter": {
+              "value": "{100%.brand.jupiter.300}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.300}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.300}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.400}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.400}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.300}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.300}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.300}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.300}",
+              "type": "color"
+            }
+          }
+        },
+        "border": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.900}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.900}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.900}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "jupiter": {
+              "value": "{100%.brand.jupiter.900}",
+              "type": "color"
+            },
+            "uranus": {
+              "value": "{100%.brand.uranus.900}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.900}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.900}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.800}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.900}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.800}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.800}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.800}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.800}",
+              "type": "color"
+            }
+          }
+        },
+        "text": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.900}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.900}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.900}",
+              "type": "color"
+            },
+            "pure-inv": {
+              "value": "{100%.grey.50}",
+              "type": "color"
+            },
+            "brand-inv": {
+              "value": "{100%.grey.100}",
+              "type": "color"
+            },
+            "muted-inv": {
+              "value": "{100%.grey.200}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "jupiter": {
+              "value": "{100%.brand.jupiter.700}",
+              "type": "color"
+            },
+            "uranus": {
+              "value": "{100%.brand.uranus.800}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.700}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.800}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.500}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.500}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.700}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.800}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.600}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.600}",
+              "type": "color"
+            }
+          }
+        },
+        "icon": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.900}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.800}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.600}",
+              "type": "color"
+            },
+            "pure-inv": {
+              "value": "{100%.grey.50}",
+              "type": "color"
+            },
+            "brand-inv": {
+              "value": "{100%.grey.100}",
+              "type": "color"
+            },
+            "muted-inv": {
+              "value": "{100%.grey.200}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "jupiter": {
+              "value": "{100%.brand.jupiter.700}",
+              "type": "color"
+            },
+            "uranus": {
+              "value": "{100%.brand.uranus.800}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.700}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.800}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.500}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.500}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.700}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.800}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.600}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.600}",
+              "type": "color"
+            }
+          }
+        },
+        "shadow": {
+          "grey": {
+            "pure": {
+              "value": "{100%.grey.400}",
+              "type": "color"
+            },
+            "brand": {
+              "value": "{100%.grey.500}",
+              "type": "color"
+            },
+            "muted": {
+              "value": "{100%.grey.600}",
+              "type": "color"
+            }
+          },
+          "brand": {
+            "uranus": {
+              "value": "{100%.brand.uranus.600}",
+              "type": "color"
+            },
+            "jupiter": {
+              "value": "{100%.brand.jupiter.600}",
+              "type": "color"
+            },
+            "neptune": {
+              "value": "{100%.brand.neptune.600}",
+              "type": "color"
+            },
+            "saturn": {
+              "value": "{100%.brand.saturn.600}",
+              "type": "color"
+            },
+            "cosmic": {
+              "value": "{100%.brand.cosmic.600}",
+              "type": "color"
+            },
+            "nebula": {
+              "value": "{100%.brand.nebula.600}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "value": "{100%.alert.info.600}",
+              "type": "color"
+            },
+            "warning": {
+              "value": "{100%.alert.warning.600}",
+              "type": "color"
+            },
+            "success": {
+              "value": "{100%.alert.success.600}",
+              "type": "color"
+            },
+            "error": {
+              "value": "{100%.alert.error.600}",
+              "type": "color"
+            }
+          }
+        }
+      },
+      "00": {
+        "value": "#ffffff",
+        "type": "color"
+      }
+    },
+    "contrast-shades": {
+      "grey": {
+        "grey-low": {
+          "value": "{100%.grey.600}",
+          "type": "color"
+        },
+        "grey-med-low": {
+          "value": "{100%.grey.700}",
+          "type": "color"
+        },
+        "grey-med-high": {
+          "value": "{100%.grey.800}",
+          "type": "color"
+        },
+        "grey-high": {
+          "value": "{100%.grey.900}",
+          "type": "color"
+        }
+      },
+      "brand": {
+        "jupiter-medium": {
+          "value": "{100%.brand.jupiter.700}",
+          "type": "color"
+        },
+        "jupiter-high": {
+          "value": "{100%.brand.jupiter.800}",
+          "type": "color"
+        },
+        "jupiter-low": {
+          "value": "{100%.brand.jupiter.300}",
+          "type": "color"
+        },
+        "uranus-low": {
+          "value": "{100%.brand.uranus.800}",
+          "type": "color"
+        },
+        "uranus-medium": {
+          "value": "{100%.brand.uranus.900}",
+          "type": "color"
+        },
+        "uranus-high": {
+          "value": "{100%.brand.uranus.900}",
+          "type": "color"
+        },
+        "neptune-low": {
+          "value": "{100%.brand.neptune.700}",
+          "type": "color"
+        },
+        "neptune-medium": {
+          "value": "{100%.brand.neptune.800}",
+          "type": "color"
+        },
+        "neptune-high": {
+          "value": "{100%.brand.neptune.900}",
+          "type": "color"
+        },
+        "saturn-low": {
+          "value": "{100%.brand.saturn.800}",
+          "type": "color"
+        },
+        "saturn-medium": {
+          "value": "{100%.brand.saturn.800}",
+          "type": "color"
+        },
+        "saturn-high": {
+          "value": "{100%.brand.saturn.900}",
+          "type": "color"
+        },
+        "cosmic-low": {
+          "value": "{100%.brand.cosmic.500}",
+          "type": "color"
+        },
+        "cosmic-medium": {
+          "value": "{100%.brand.cosmic.700}",
+          "type": "color"
+        },
+        "cosmic-high": {
+          "value": "{100%.brand.cosmic.800}",
+          "type": "color"
+        },
+        "nebula-low": {
+          "value": "{100%.brand.nebula.500}",
+          "type": "color"
+        },
+        "nebula-medium": {
+          "value": "{100%.brand.nebula.700}",
+          "type": "color"
+        },
+        "nebula-high": {
+          "value": "{100%.brand.nebula.800}",
+          "type": "color"
+        }
+      },
+      "alert": {
+        "success-low": {
+          "value": "{100%.alert.success.700}",
+          "type": "color"
+        },
+        "success-medium": {
+          "value": "{100%.alert.success.800}",
+          "type": "color"
+        },
+        "success-high": {
+          "value": "{100%.alert.success.900}",
+          "type": "color"
+        },
+        "info-low": {
+          "value": "{100%.alert.info.700}",
+          "type": "color"
+        },
+        "info-medium": {
+          "value": "{100%.alert.info.800}",
+          "type": "color"
+        },
+        "info-high": {
+          "value": "{100%.alert.info.900}",
+          "type": "color"
+        },
+        "warning-low": {
+          "value": "{100%.alert.warning.700}",
+          "type": "color"
+        },
+        "warning-medium": {
+          "value": "{100%.alert.warning.800}",
+          "type": "color"
+        },
+        "warning-high": {
+          "value": "{100%.alert.warning.900}",
+          "type": "color"
+        },
+        "error-low": {
+          "value": "{100%.alert.error.700}",
+          "type": "color"
+        },
+        "error-medium": {
+          "value": "{100%.alert.error.800}",
+          "type": "color"
+        },
+        "error-high": {
+          "value": "{100%.alert.error.900}",
+          "type": "color"
+        }
+      }
+    },
+    "is-dark-mode": {
+      "value": "false",
+      "type": "boolean"
+    },
+    "is-light-mode": {
+      "value": "true",
+      "type": "boolean"
+    }
+  },
+  "status/default": {
+    "dep*": {
+      "alert": {
+        "error": {
+          "value": "{contrast-shades.alert.error-low}",
+          "type": "color"
+        },
+        "warning": {
+          "value": "{contrast-shades.alert.warning-low}",
+          "type": "color"
+        },
+        "notification": {
+          "value": "{contrast-shades.alert.info-low}",
+          "type": "color"
+        },
+        "success": {
+          "value": "{contrast-shades.alert.success-low}",
+          "type": "color"
+        }
+      },
+      "content": {
+        "link": {
+          "default": {
+            "value": "{dynamic.text.default.link.default}",
+            "type": "color"
+          },
+          "focus": {
+            "value": "{dynamic.text.default.link.default}",
+            "type": "color"
+          },
+          "active": {
+            "value": "{dynamic.text.default.link.default}",
+            "type": "color"
+          },
+          "visited": {
+            "value": "{dynamic.text.default.link.default}",
+            "type": "color"
+          },
+          "disabled": {
+            "value": "{dynamic.text.default.link.default}",
+            "type": "color"
+          }
+        },
+        "alert": {
+          "error": {
+            "value": "{dynamic.text.default.alert.error}",
+            "type": "color"
+          },
+          "warning": {
+            "value": "{dynamic.text.default.alert.warning}",
+            "type": "color"
+          },
+          "notification": {
+            "value": "{dynamic.text.default.alert.notification}",
+            "type": "color"
+          },
+          "success": {
+            "value": "{dynamic.text.default.alert.success}",
+            "type": "color"
+          }
+        },
+        "btn": {
+          "primary": {
+            "brand": {
+              "value": "{contrast-shades.inv.grey.g-4}",
+              "type": "color"
+            },
+            "gray": {
+              "value": "{contrast-shades.inv.grey.g-4}",
+              "type": "color"
+            }
+          },
+          "secondary": {
+            "brand": {
+              "value": "{contrast-shades.brand.nebula-low}",
+              "type": "color"
+            },
+            "gray": {
+              "value": "{contrast-shades.grey.grey-high}",
+              "type": "color"
+            }
+          },
+          "tertiary": {
+            "brand": {
+              "value": "{contrast-shades.brand.nebula-low}",
+              "type": "color"
+            },
+            "gray": {
+              "value": "{contrast-shades.grey.grey-high}",
+              "type": "color"
+            }
+          }
+        }
+      },
+      "link": {
+        "default": {
+          "value": "{dynamic.background.default.link.link}",
+          "type": "color"
+        },
+        "active": {
+          "value": "{dynamic.background.default.link.link}",
+          "type": "color"
+        },
+        "visited": {
+          "value": "{dynamic.background.default.link.link}",
+          "type": "color"
+        },
+        "disabled": {
+          "value": "{dynamic.background.default.link.link}",
+          "type": "color"
+        },
+        "focus": {
+          "value": "{dynamic.background.default.link.link}",
+          "type": "color"
+        }
+      },
+      "border": {
+        "link": {
+          "default": {
+            "value": "{dynamic.border.default.link.default}",
+            "type": "color"
+          },
+          "active": {
+            "value": "{dynamic.border.default.link.default}",
+            "type": "color"
+          },
+          "visited": {
+            "value": "{dynamic.border.default.link.default}",
+            "type": "color"
+          },
+          "disabled": {
+            "value": "{dynamic.border.default.link.default}",
+            "type": "color"
+          },
+          "focus": {
+            "value": "{dynamic.border.default.link.default}",
+            "type": "color"
+          }
+        },
+        "alert": {
+          "error": {
+            "value": "{dynamic.border.default.alert.error}",
+            "type": "color"
+          },
+          "warning": {
+            "value": "{dynamic.border.default.alert.warning}",
+            "type": "color"
+          },
+          "notification": {
+            "value": "{dynamic.border.default.alert.notification}",
+            "type": "color"
+          },
+          "success": {
+            "value": "{dynamic.border.default.alert.success}",
+            "type": "color"
+          }
+        },
+        "btn": {
+          "primary": {
+            "brand": {
+              "value": "{contrast-shades.brand.nebula-high}",
+              "type": "color"
+            },
+            "grey": {
+              "value": "{contrast-shades.grey.grey-high}",
+              "type": "color"
+            }
+          },
+          "secondary": {
+            "brand": {
+              "value": "{contrast-shades.brand.nebula-low}",
+              "type": "color"
+            },
+            "gray": {
+              "value": "{contrast-shades.grey.grey-high}",
+              "type": "color"
+            }
+          },
+          "tertiary": {
+            "brand": {
+              "value": "{0%.transparent}",
+              "type": "color"
+            },
+            "gray": {
+              "value": "{0%.transparent}",
+              "type": "color"
+            }
+          }
+        }
+      },
+      "btn": {
+        "primary": {
+          "brand": {
+            "value": "{contrast-shades.brand.nebula-medium}",
+            "type": "color"
+          },
+          "gray": {
+            "value": "{contrast-shades.grey.grey-med-high}",
+            "type": "color"
+          }
+        },
+        "secondary": {
+          "gray": {
+            "value": "{0%.transparent}",
+            "type": "color"
+          },
+          "brand": {
+            "value": "{0%.transparent}",
+            "type": "color"
+          }
+        },
+        "tertiary": {
+          "brand": {
+            "value": "{0%.transparent}",
+            "type": "color"
+          },
+          "gray": {
+            "value": "{0%.transparent}",
+            "type": "color"
+          }
+        }
+      }
+    },
+    "btn": {
+      "surface": {
+        "brand": {
+          "primary": {
+            "value": "{status.default.surface.btn.brand.primary}",
+            "type": "color"
+          },
+          "secondary": {
+            "value": "{status.default.surface.btn.brand.secondary}",
+            "type": "color"
+          },
+          "tertiary": {
+            "value": "{status.default.surface.btn.brand.tertiary}",
+            "type": "color"
+          }
+        },
+        "grey": {
+          "primary": {
+            "value": "{status.default.surface.btn.grey.primary}",
+            "type": "color"
+          },
+          "secondary": {
+            "value": "{status.default.surface.btn.grey.secondary}",
+            "type": "color"
+          },
+          "tertiary": {
+            "value": "{status.default.surface.btn.grey.tertiary}",
+            "type": "color"
+          }
+        },
+        "alert": {
+          "info": {
+            "primary": {
+              "value": "{status.default.surface.btn.alert.info.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.default.surface.btn.alert.info.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.default.surface.btn.alert.info.tertiary}",
+              "type": "color"
+            }
+          },
+          "success": {
+            "primary": {
+              "value": "{status.default.surface.btn.alert.success.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.default.surface.btn.alert.success.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.default.surface.btn.alert.success.tertiary}",
+              "type": "color"
+            }
+          },
+          "warning": {
+            "primary": {
+              "value": "{status.default.surface.btn.alert.warning.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.default.surface.btn.alert.warning.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.default.surface.btn.alert.warning.tertiary}",
+              "type": "color"
+            }
+          },
+          "error": {
+            "primary": {
+              "value": "{status.default.surface.btn.alert.error.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.default.surface.btn.alert.error.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.default.surface.btn.alert.error.tertiary}",
+              "type": "color"
+            }
+          }
+        }
+      },
+      "content": {
+        "brand": {
+          "primary": {
+            "value": "{status.default.content.btn.brand.primary}",
+            "type": "color"
+          },
+          "secondary": {
+            "value": "{status.default.content.btn.brand.secondary}",
+            "type": "color"
+          },
+          "tertiary": {
+            "value": "{status.default.content.btn.brand.tertiary}",
+            "type": "color"
+          }
+        },
+        "grey": {
+          "primary": {
+            "value": "{status.default.content.btn.grey.primary}",
+            "type": "color"
+          },
+          "secondary": {
+            "value": "{status.default.content.btn.grey.secondary}",
+            "type": "color"
+          },
+          "tertiary": {
+            "value": "{status.default.content.btn.grey.tertiary}",
+            "type": "color"
+          }
+        },
+        "alert": {
+          "info": {
+            "primary": {
+              "value": "{status.default.content.btn.alert.info.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.default.content.btn.alert.info.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.default.content.btn.alert.info.tertiary}",
+              "type": "color"
+            }
+          },
+          "success": {
+            "primary": {
+              "value": "{status.default.content.btn.alert.success.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.default.content.btn.alert.success.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.default.content.btn.alert.success.tertiary}",
+              "type": "color"
+            }
+          },
+          "warning": {
+            "primary": {
+              "value": "{status.default.content.btn.alert.warning.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.default.content.btn.alert.warning.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.default.content.btn.alert.warning.tertiary}",
+              "type": "color"
+            }
+          },
+          "error": {
+            "primary": {
+              "value": "{status.default.content.btn.alert.error.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.default.content.btn.alert.error.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.default.content.btn.alert.error.tertiary}",
+              "type": "color"
+            }
+          }
+        },
+        "icon-size": {
+          "value": "{button.default.icon.icon-size}",
+          "type": "dimension"
+        }
+      },
+      "border": {
+        "brand": {
+          "primary": {
+            "value": "{status.default.border.btn.brand.primary}",
+            "type": "color"
+          },
+          "secondary": {
+            "value": "{status.default.border.btn.brand.secondary}",
+            "type": "color"
+          },
+          "tertiary": {
+            "value": "{status.default.border.btn.brand.tertiary}",
+            "type": "color"
+          }
+        },
+        "grey": {
+          "primary": {
+            "value": "{status.default.border.btn.grey.primary}",
+            "type": "color"
+          },
+          "secondary": {
+            "value": "{status.default.border.btn.grey.secondary}",
+            "type": "color"
+          },
+          "tertiary": {
+            "value": "{status.default.border.btn.grey.tertiary}",
+            "type": "color"
+          }
+        },
+        "alert": {
+          "info": {
+            "primary": {
+              "value": "{status.default.border.btn.alert.info.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.default.border.btn.alert.info.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.default.border.btn.alert.info.tertiary}",
+              "type": "color"
+            }
+          },
+          "success": {
+            "primary": {
+              "value": "{status.default.border.btn.alert.success.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.default.border.btn.alert.success.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.default.border.btn.alert.success.tertiary}",
+              "type": "color"
+            }
+          },
+          "warning": {
+            "primary": {
+              "value": "{status.default.border.btn.alert.warning.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.default.border.btn.alert.warning.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.default.border.btn.alert.warning.tertiary}",
+              "type": "color"
+            }
+          },
+          "error": {
+            "primary": {
+              "value": "{status.default.border.btn.alert.error.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.default.border.btn.alert.error.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.default.border.btn.alert.error.tertiary}",
+              "type": "color"
+            }
+          }
+        },
+        "width": {
+          "value": "{button.default.border.width}",
+          "type": "dimension"
+        },
+        "radius": {
+          "value": "{button.default.border.radius}",
+          "type": "dimension"
+        }
+      },
+      "indicator": {
+        "surface": {
+          "brand": {
+            "primary": {
+              "value": "{status.default.indicator.surface.btn.brand.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.default.indicator.surface.btn.brand.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.default.indicator.surface.btn.brand.tertiary}",
+              "type": "color"
+            }
+          },
+          "grey": {
+            "primary": {
+              "value": "{status.default.indicator.surface.btn.grey.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.default.indicator.surface.btn.grey.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.default.indicator.surface.btn.grey.tertiary}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "primary": {
+                "value": "{status.default.indicator.surface.btn.alert.info.primary}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{status.default.indicator.surface.btn.alert.info.secondary}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{status.default.indicator.surface.btn.alert.info.tertiary}",
+                "type": "color"
+              }
+            },
+            "success": {
+              "primary": {
+                "value": "{status.default.indicator.surface.btn.alert.success.primary}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{status.default.indicator.surface.btn.alert.success.secondary}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{status.default.indicator.surface.btn.alert.success.tertiary}",
+                "type": "color"
+              }
+            },
+            "warning": {
+              "primary": {
+                "value": "{status.default.indicator.surface.btn.alert.warning.primary}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{status.default.indicator.surface.btn.alert.warning.secondary}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{status.default.indicator.surface.btn.alert.warning.tertiary}",
+                "type": "color"
+              }
+            },
+            "error": {
+              "primary": {
+                "value": "{status.default.indicator.surface.btn.alert.error.primary}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{status.default.indicator.surface.btn.alert.error.secondary}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{status.default.indicator.surface.btn.alert.error.tertiary}",
+                "type": "color"
+              }
+            }
+          }
+        },
+        "border": {
+          "brand": {
+            "primary": {
+              "value": "{status.default.indicator.border.btn.brand.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.default.indicator.border.btn.brand.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.default.indicator.border.btn.brand.tertiary}",
+              "type": "color"
+            }
+          },
+          "grey": {
+            "primary": {
+              "value": "{status.default.indicator.border.btn.grey.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.default.indicator.border.btn.grey.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.default.indicator.border.btn.grey.tertiary}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "primary": {
+                "value": "{status.default.indicator.border.btn.alert.info.primary}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{status.default.indicator.border.btn.alert.info.secondary}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{status.default.indicator.border.btn.alert.info.tertiary}",
+                "type": "color"
+              }
+            },
+            "success": {
+              "primary": {
+                "value": "{status.default.indicator.border.btn.alert.success.primary}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{status.default.indicator.border.btn.alert.success.secondary}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{status.default.indicator.border.btn.alert.success.tertiary}",
+                "type": "color"
+              }
+            },
+            "warning": {
+              "primary": {
+                "value": "{status.default.indicator.border.btn.alert.warning.primary}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{status.default.indicator.border.btn.alert.warning.secondary}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{status.default.indicator.border.btn.alert.warning.tertiary}",
+                "type": "color"
+              }
+            },
+            "error": {
+              "primary": {
+                "value": "{status.default.indicator.border.btn.alert.error.primary}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{status.default.indicator.border.btn.alert.error.secondary}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{status.default.indicator.border.btn.alert.error.tertiary}",
+                "type": "color"
+              }
+            }
+          },
+          "width": {
+            "value": "{button.default.indicator.border.width}",
+            "type": "dimension"
+          },
+          "radius": {
+            "value": "{button.default.indicator.border.radius}",
+            "type": "dimension"
+          }
+        },
+        "space": {
+          "start-x": {
+            "value": "{button.default.indicator.padding.start-x}",
+            "type": "dimension"
+          },
+          "top-y": {
+            "value": "{button.default.indicator.padding.p-y}",
+            "type": "dimension"
+          },
+          "end-x": {
+            "value": "{button.default.indicator.padding.end-x}",
+            "type": "dimension"
+          },
+          "bottom-y": {
+            "value": "{button.default.indicator.padding.p-y}",
+            "type": "dimension"
+          }
+        }
+      },
+      "weight": {
+        "font-weight": {
+          "value": "{button.default.text.font-weight}",
+          "type": "text"
+        }
+      },
+      "space": {
+        "p-x": {
+          "value": "{button.default.space.p-x}",
+          "type": "dimension"
+        },
+        "p-y": {
+          "value": "{button.default.space.p-y}",
+          "type": "dimension"
+        },
+        "g-x": {
+          "value": "{button.default.space.g-x}",
+          "type": "dimension"
+        },
+        "g-y": {
+          "value": "{button.default.space.g-y}",
+          "type": "dimension"
+        }
+      }
+    },
+    "is-default": {
+      "value": "true",
+      "type": "boolean"
+    },
+    "is-hover": {
+      "value": "false",
+      "type": "boolean"
+    },
+    "is-focus": {
+      "value": "false",
+      "type": "boolean"
+    },
+    "is-active": {
+      "value": "false",
+      "type": "boolean"
+    }
+  },
+  "status/hover": {
+    "dep*": {
+      "alert": {
+        "error": {
+          "value": "{contrast-shades.alert.error-medium}",
+          "type": "color"
+        },
+        "warning": {
+          "value": "{contrast-shades.alert.warning-medium}",
+          "type": "color"
+        },
+        "notification": {
+          "value": "{contrast-shades.alert.info-medium}",
+          "type": "color"
+        },
+        "success": {
+          "value": "{contrast-shades.alert.success-medium}",
+          "type": "color"
+        }
+      },
+      "content": {
+        "link": {
+          "default": {
+            "value": "{dynamic.text.hover.link.hover}",
+            "type": "color"
+          },
+          "focus": {
+            "value": "{dynamic.text.hover.link.hover}",
+            "type": "color"
+          },
+          "active": {
+            "value": "{dynamic.text.hover.link.hover}",
+            "type": "color"
+          },
+          "visited": {
+            "value": "{dynamic.text.hover.link.hover}",
+            "type": "color"
+          },
+          "disabled": {
+            "value": "{dynamic.text.hover.link.hover}",
+            "type": "color"
+          }
+        },
+        "alert": {
+          "error": {
+            "value": "{dynamic.text.hover.alert.error}",
+            "type": "color"
+          },
+          "warning": {
+            "value": "{dynamic.text.hover.alert.warning}",
+            "type": "color"
+          },
+          "notification": {
+            "value": "{dynamic.text.hover.alert.notification}",
+            "type": "color"
+          },
+          "success": {
+            "value": "{dynamic.text.hover.alert.success}",
+            "type": "color"
+          }
+        },
+        "btn": {
+          "primary": {
+            "brand": {
+              "value": "{contrast-shades.inv.grey.g-4}",
+              "type": "color"
+            },
+            "gray": {
+              "value": "{contrast-shades.inv.grey.g-4}",
+              "type": "color"
+            }
+          },
+          "secondary": {
+            "brand": {
+              "value": "{contrast-shades.brand.nebula-high}",
+              "type": "color"
+            },
+            "gray": {
+              "value": "{contrast-shades.inv.grey.g-4}",
+              "type": "color"
+            }
+          },
+          "tertiary": {
+            "brand": {
+              "value": "{contrast-shades.brand.nebula-high}",
+              "type": "color"
+            },
+            "gray": {
+              "value": "{contrast-shades.grey.grey-high}",
+              "type": "color"
+            }
+          }
+        }
+      },
+      "link": {
+        "default": {
+          "value": "{dynamic.background.hover.link.link}",
+          "type": "color"
+        },
+        "active": {
+          "value": "{dynamic.background.hover.link.link}",
+          "type": "color"
+        },
+        "visited": {
+          "value": "{dynamic.background.hover.link.link}",
+          "type": "color"
+        },
+        "disabled": {
+          "value": "{dynamic.background.hover.link.link}",
+          "type": "color"
+        },
+        "focus": {
+          "value": "{dynamic.background.hover.link.link}",
+          "type": "color"
+        }
+      },
+      "border": {
+        "link": {
+          "default": {
+            "value": "{dynamic.border.hover.link.hover}",
+            "type": "color"
+          },
+          "active": {
+            "value": "{dynamic.border.hover.link.hover}",
+            "type": "color"
+          },
+          "visited": {
+            "value": "{dynamic.border.hover.link.hover}",
+            "type": "color"
+          },
+          "disabled": {
+            "value": "{dynamic.border.hover.link.hover}",
+            "type": "color"
+          },
+          "focus": {
+            "value": "{dynamic.border.hover.link.hover}",
+            "type": "color"
+          }
+        },
+        "alert": {
+          "error": {
+            "value": "{dynamic.border.hover.alert.error}",
+            "type": "color"
+          },
+          "warning": {
+            "value": "{dynamic.border.hover.alert.warning}",
+            "type": "color"
+          },
+          "notification": {
+            "value": "{dynamic.border.hover.alert.notification}",
+            "type": "color"
+          },
+          "success": {
+            "value": "{dynamic.background.hover.alert.success}",
+            "type": "color"
+          }
+        },
+        "btn": {
+          "primary": {
+            "brand": {
+              "value": "{contrast-shades.brand.nebula-low}",
+              "type": "color"
+            },
+            "grey": {
+              "value": "{contrast-shades.grey.grey-med-low}",
+              "type": "color"
+            }
+          },
+          "secondary": {
+            "brand": {
+              "value": "{contrast-shades.brand.nebula-low}",
+              "type": "color"
+            },
+            "gray": {
+              "value": "{contrast-shades.grey.grey-med-high}",
+              "type": "color"
+            }
+          },
+          "tertiary": {
+            "brand": {
+              "value": "{contrast-shades.inv.brand.ne-3 2}",
+              "type": "color"
+            },
+            "gray": {
+              "value": "{contrast-shades.inv.grey.g-2}",
+              "type": "color"
+            }
+          }
+        }
+      },
+      "btn": {
+        "primary": {
+          "brand": {
+            "value": "{contrast-shades.brand.nebula-high}",
+            "type": "color"
+          },
+          "gray": {
+            "value": "{contrast-shades.grey.grey-high}",
+            "type": "color"
+          }
+        },
+        "secondary": {
+          "gray": {
+            "value": "{contrast-shades.grey.grey-med-low}",
+            "type": "color"
+          },
+          "brand": {
+            "value": "{contrast-shades.inv.brand.ne-3 2}",
+            "type": "color"
+          }
+        },
+        "tertiary": {
+          "brand": {
+            "value": "{contrast-shades.inv.brand.ne-3 2}",
+            "type": "color"
+          },
+          "gray": {
+            "value": "{contrast-shades.inv.grey.g-2}",
+            "type": "color"
+          }
+        }
+      }
+    },
+    "btn": {
+      "surface": {
+        "brand": {
+          "primary": {
+            "value": "{status.hover.surface.btn.brand.primary}",
+            "type": "color"
+          },
+          "secondary": {
+            "value": "{status.hover.surface.btn.brand.secondary}",
+            "type": "color"
+          },
+          "tertiary": {
+            "value": "{status.hover.surface.btn.brand.tertiary}",
+            "type": "color"
+          }
+        },
+        "grey": {
+          "primary": {
+            "value": "{status.hover.surface.btn.grey.primary}",
+            "type": "color"
+          },
+          "secondary": {
+            "value": "{status.hover.surface.btn.grey.secondary}",
+            "type": "color"
+          },
+          "tertiary": {
+            "value": "{status.hover.surface.btn.grey.tertiary}",
+            "type": "color"
+          }
+        },
+        "alert": {
+          "info": {
+            "primary": {
+              "value": "{status.hover.surface.btn.alert.info.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.hover.surface.btn.alert.info.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.hover.surface.btn.alert.info.tertiary}",
+              "type": "color"
+            }
+          },
+          "success": {
+            "primary": {
+              "value": "{status.hover.surface.btn.alert.success.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.hover.surface.btn.alert.success.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.hover.surface.btn.alert.success.tertiary}",
+              "type": "color"
+            }
+          },
+          "warning": {
+            "primary": {
+              "value": "{status.hover.surface.btn.alert.warning.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.hover.surface.btn.alert.warning.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.hover.surface.btn.alert.warning.tertiary}",
+              "type": "color"
+            }
+          },
+          "error": {
+            "primary": {
+              "value": "{status.hover.surface.btn.alert.error.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.hover.surface.btn.alert.error.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.hover.surface.btn.alert.error.tertiary}",
+              "type": "color"
+            }
+          }
+        }
+      },
+      "content": {
+        "brand": {
+          "primary": {
+            "value": "{status.hover.content.btn.brand.primary}",
+            "type": "color"
+          },
+          "secondary": {
+            "value": "{status.hover.content.btn.brand.secondary}",
+            "type": "color"
+          },
+          "tertiary": {
+            "value": "{status.hover.content.btn.brand.tertiary}",
+            "type": "color"
+          }
+        },
+        "grey": {
+          "primary": {
+            "value": "{status.hover.content.btn.grey.primary}",
+            "type": "color"
+          },
+          "secondary": {
+            "value": "{status.hover.content.btn.grey.secondary}",
+            "type": "color"
+          },
+          "tertiary": {
+            "value": "{status.hover.content.btn.grey.tertiary}",
+            "type": "color"
+          }
+        },
+        "alert": {
+          "info": {
+            "primary": {
+              "value": "{status.hover.content.btn.alert.info.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.hover.content.btn.alert.info.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.hover.content.btn.alert.info.tertiary}",
+              "type": "color"
+            }
+          },
+          "success": {
+            "primary": {
+              "value": "{status.hover.content.btn.alert.success.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.hover.content.btn.alert.success.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.hover.content.btn.alert.success.tertiary}",
+              "type": "color"
+            }
+          },
+          "warning": {
+            "primary": {
+              "value": "{status.hover.content.btn.alert.warning.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.hover.content.btn.alert.warning.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.hover.content.btn.alert.warning.tertiary}",
+              "type": "color"
+            }
+          },
+          "error": {
+            "primary": {
+              "value": "{status.hover.content.btn.grey.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.hover.content.btn.alert.error.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.hover.content.btn.alert.error.tertiary}",
+              "type": "color"
+            }
+          }
+        },
+        "icon-size": {
+          "value": "{button.hover.icon.icon-size}",
+          "type": "dimension"
+        }
+      },
+      "border": {
+        "brand": {
+          "primary": {
+            "value": "{status.hover.border.btn.brand.primary}",
+            "type": "color"
+          },
+          "secondary": {
+            "value": "{status.hover.border.btn.brand.secondary}",
+            "type": "color"
+          },
+          "tertiary": {
+            "value": "{status.hover.border.btn.brand.tertiary}",
+            "type": "color"
+          }
+        },
+        "grey": {
+          "primary": {
+            "value": "{status.hover.border.btn.grey.primary}",
+            "type": "color"
+          },
+          "secondary": {
+            "value": "{status.hover.border.btn.grey.secondary}",
+            "type": "color"
+          },
+          "tertiary": {
+            "value": "{status.hover.border.btn.grey.tertiary}",
+            "type": "color"
+          }
+        },
+        "alert": {
+          "info": {
+            "primary": {
+              "value": "{status.hover.border.btn.alert.info.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.hover.border.btn.alert.info.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.hover.border.btn.alert.info.tertiary}",
+              "type": "color"
+            }
+          },
+          "success": {
+            "primary": {
+              "value": "{status.hover.border.btn.alert.success.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.hover.border.btn.alert.success.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.hover.border.btn.alert.success.tertiary}",
+              "type": "color"
+            }
+          },
+          "warning": {
+            "primary": {
+              "value": "{status.hover.border.btn.alert.warning.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.hover.border.btn.alert.warning.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.hover.border.btn.alert.warning.tertiary}",
+              "type": "color"
+            }
+          },
+          "error": {
+            "primary": {
+              "value": "{status.hover.border.btn.alert.error.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.hover.border.btn.alert.error.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.hover.border.btn.alert.error.tertiary}",
+              "type": "color"
+            }
+          }
+        },
+        "width": {
+          "value": "{button.hover.border.width}",
+          "type": "dimension"
+        },
+        "radius": {
+          "value": "{button.hover.border.radius}",
+          "type": "dimension"
+        }
+      },
+      "indicator": {
+        "surface": {
+          "brand": {
+            "primary": {
+              "value": "{status.hover.indicator.surface.btn.brand.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.hover.indicator.surface.btn.brand.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.hover.indicator.surface.btn.brand.tertiary}",
+              "type": "color"
+            }
+          },
+          "grey": {
+            "primary": {
+              "value": "{status.hover.indicator.surface.btn.grey.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.hover.indicator.surface.btn.grey.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.hover.indicator.surface.btn.grey.tertiary}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "primary": {
+                "value": "{status.hover.indicator.surface.btn.alert.info.primary}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{status.hover.indicator.surface.btn.alert.info.secondary}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{status.hover.indicator.surface.btn.alert.info.tertiary}",
+                "type": "color"
+              }
+            },
+            "success": {
+              "primary": {
+                "value": "{status.hover.indicator.surface.btn.alert.success.primary}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{status.hover.indicator.surface.btn.alert.success.secondary}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{status.hover.indicator.surface.btn.alert.success.tertiary}",
+                "type": "color"
+              }
+            },
+            "warning": {
+              "primary": {
+                "value": "{status.hover.indicator.surface.btn.alert.warning.primary}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{status.hover.indicator.surface.btn.alert.warning.secondary}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{status.hover.indicator.surface.btn.alert.warning.tertiary}",
+                "type": "color"
+              }
+            },
+            "error": {
+              "primary": {
+                "value": "{status.hover.indicator.surface.btn.alert.error.primary}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{status.hover.indicator.surface.btn.alert.error.secondary}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{status.hover.indicator.surface.btn.alert.error.tertiary}",
+                "type": "color"
+              }
+            }
+          }
+        },
+        "border": {
+          "brand": {
+            "primary": {
+              "value": "{status.hover.indicator.border.btn.brand.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.hover.indicator.border.btn.brand.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.hover.indicator.border.btn.brand.tertiary}",
+              "type": "color"
+            }
+          },
+          "grey": {
+            "primary": {
+              "value": "{status.hover.indicator.border.btn.grey.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.hover.indicator.border.btn.grey.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.hover.indicator.border.btn.grey.tertiary}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "primary": {
+                "value": "{status.hover.indicator.border.btn.alert.info.primary}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{status.hover.indicator.border.btn.alert.info.secondary}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{status.hover.indicator.border.btn.alert.info.tertiary}",
+                "type": "color"
+              }
+            },
+            "success": {
+              "primary": {
+                "value": "{status.hover.indicator.border.btn.alert.success.primary}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{status.hover.indicator.border.btn.alert.success.secondary}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{status.hover.indicator.border.btn.alert.success.tertiary}",
+                "type": "color"
+              }
+            },
+            "warning": {
+              "primary": {
+                "value": "{status.hover.indicator.border.btn.alert.warning.primary}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{status.hover.indicator.border.btn.alert.warning.secondary}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{status.hover.indicator.border.btn.alert.warning.tertiary}",
+                "type": "color"
+              }
+            },
+            "error": {
+              "primary": {
+                "value": "{status.hover.indicator.border.btn.alert.error.primary}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{status.hover.indicator.border.btn.alert.error.secondary}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{status.hover.indicator.border.btn.alert.error.tertiary}",
+                "type": "color"
+              }
+            }
+          },
+          "width": {
+            "value": "{button.hover.indicator.border.width}",
+            "type": "dimension"
+          },
+          "radius": {
+            "value": "{button.hover.indicator.border.radius}",
+            "type": "dimension"
+          }
+        },
+        "space": {
+          "start-x": {
+            "value": "{button.hover.indicator.padding.start-x}",
+            "type": "dimension"
+          },
+          "top-y": {
+            "value": "{button.hover.indicator.padding.p-y}",
+            "type": "dimension"
+          },
+          "end-x": {
+            "value": "{button.hover.indicator.padding.end-x}",
+            "type": "dimension"
+          },
+          "bottom-y": {
+            "value": "{button.hover.indicator.padding.p-y}",
+            "type": "dimension"
+          }
+        }
+      },
+      "weight": {
+        "font-weight": {
+          "value": "{button.hover.text.font-weight}",
+          "type": "text"
+        }
+      },
+      "space": {
+        "p-x": {
+          "value": "{button.hover.space.p-x}",
+          "type": "dimension"
+        },
+        "p-y": {
+          "value": "{button.hover.space.p-y}",
+          "type": "dimension"
+        },
+        "g-x": {
+          "value": "{button.hover.space.g-x}",
+          "type": "dimension"
+        },
+        "g-y": {
+          "value": "{button.hover.space.g-y}",
+          "type": "dimension"
+        }
+      }
+    },
+    "is-default": {
+      "value": "false",
+      "type": "boolean"
+    },
+    "is-hover": {
+      "value": "true",
+      "type": "boolean"
+    },
+    "is-focus": {
+      "value": "false",
+      "type": "boolean"
+    },
+    "is-active": {
+      "value": "false",
+      "type": "boolean"
+    }
+  },
+  "status/focus": {
+    "dep*": {
+      "alert": {
+        "error": {
+          "value": "{contrast-shades.alert.error-high}",
+          "type": "color"
+        },
+        "warning": {
+          "value": "{contrast-shades.alert.warning-high}",
+          "type": "color"
+        },
+        "notification": {
+          "value": "{contrast-shades.alert.info-high}",
+          "type": "color"
+        },
+        "success": {
+          "value": "{contrast-shades.alert.success-high}",
+          "type": "color"
+        }
+      },
+      "content": {
+        "link": {
+          "default": {
+            "value": "{dep*.alert.error}",
+            "type": "color"
+          },
+          "focus": {
+            "value": "{dynamic.text.focus|active.focus}",
+            "type": "color"
+          },
+          "active": {
+            "value": "{dynamic.text.focus|active.active}",
+            "type": "color"
+          },
+          "visited": {
+            "value": "{dep*.alert.error}",
+            "type": "color"
+          },
+          "disabled": {
+            "value": "{dep*.alert.error}",
+            "type": "color"
+          }
+        },
+        "alert": {
+          "error": {
+            "value": "{dynamic.text.hover.alert.error}",
+            "type": "color"
+          },
+          "warning": {
+            "value": "{dynamic.text.hover.alert.warning}",
+            "type": "color"
+          },
+          "notification": {
+            "value": "{dynamic.text.hover.alert.notification}",
+            "type": "color"
+          },
+          "success": {
+            "value": "{dynamic.text.hover.alert.success}",
+            "type": "color"
+          }
+        },
+        "btn": {
+          "primary": {
+            "brand": {
+              "value": "{contrast-shades.grey.grey-high}",
+              "type": "color"
+            },
+            "gray": {
+              "value": "{contrast-shades.grey.grey-high}",
+              "type": "color"
+            }
+          },
+          "secondary": {
+            "brand": {
+              "value": "{contrast-shades.inv.brand.ne-3 2}",
+              "type": "color"
+            },
+            "gray": {
+              "value": "{contrast-shades.inv.grey.g-4}",
+              "type": "color"
+            }
+          },
+          "tertiary": {
+            "brand": {
+              "value": "{contrast-shades.brand.nebula-high}",
+              "type": "color"
+            },
+            "gray": {
+              "value": "{contrast-shades.grey.grey-high}",
+              "type": "color"
+            }
+          }
+        }
+      },
+      "link": {
+        "default": {
+          "value": "{dep*.alert.error}",
+          "type": "color"
+        },
+        "active": {
+          "value": "{dynamic.background.focus|active.link.active}",
+          "type": "color"
+        },
+        "visited": {
+          "value": "{dep*.alert.error}",
+          "type": "color"
+        },
+        "disabled": {
+          "value": "{dep*.alert.error}",
+          "type": "color"
+        },
+        "focus": {
+          "value": "{dynamic.background.focus|active.link.focus}",
+          "type": "color"
+        }
+      },
+      "border": {
+        "link": {
+          "default": {
+            "value": "{dep*.alert.error}",
+            "type": "color"
+          },
+          "active": {
+            "value": "{dynamic.border.focus|active.link.active}",
+            "type": "color"
+          },
+          "visited": {
+            "value": "{dep*.border.alert.error}",
+            "type": "color"
+          },
+          "disabled": {
+            "value": "{dep*.border.alert.error}",
+            "type": "color"
+          },
+          "focus": {
+            "value": "{dynamic.border.focus|active.link.focus}",
+            "type": "color"
+          }
+        },
+        "alert": {
+          "error": {
+            "value": "{dynamic.background.focus|active.alert.error}",
+            "type": "color"
+          },
+          "warning": {
+            "value": "{dynamic.background.focus|active.alert.warning}",
+            "type": "color"
+          },
+          "notification": {
+            "value": "{dynamic.background.focus|active.alert.notification}",
+            "type": "color"
+          },
+          "success": {
+            "value": "{dynamic.background.focus|active.alert.success}",
+            "type": "color"
+          }
+        },
+        "btn": {
+          "primary": {
+            "brand": {
+              "value": "{contrast-shades.brand.nebula-high}",
+              "type": "color"
+            },
+            "grey": {
+              "value": "{contrast-shades.grey.grey-high}",
+              "type": "color"
+            }
+          },
+          "secondary": {
+            "brand": {
+              "value": "{contrast-shades.brand.nebula-high}",
+              "type": "color"
+            },
+            "gray": {
+              "value": "{contrast-shades.grey.grey-low}",
+              "type": "color"
+            }
+          },
+          "tertiary": {
+            "brand": {
+              "value": "{contrast-shades.brand.nebula-low}",
+              "type": "color"
+            },
+            "gray": {
+              "value": "{contrast-shades.grey.grey-low}",
+              "type": "color"
+            }
+          }
+        }
+      },
+      "btn": {
+        "primary": {
+          "brand": {
+            "value": "{contrast-shades.inv.brand.ne-3 2}",
+            "type": "color"
+          },
+          "gray": {
+            "value": "{contrast-shades.inv.grey.g-2}",
+            "type": "color"
+          }
+        },
+        "secondary": {
+          "gray": {
+            "value": "{contrast-shades.grey.grey-med-high}",
+            "type": "color"
+          },
+          "brand": {
+            "value": "{contrast-shades.brand.nebula-low}",
+            "type": "color"
+          }
+        },
+        "tertiary": {
+          "brand": {
+            "value": "{contrast-shades.inv.brand.ne-3 2}",
+            "type": "color"
+          },
+          "gray": {
+            "value": "{contrast-shades.inv.grey.g-2}",
+            "type": "color"
+          }
+        }
+      }
+    },
+    "btn": {
+      "surface": {
+        "brand": {
+          "primary": {
+            "value": "{status.focus.surface.btn.brand.primary}",
+            "type": "color"
+          },
+          "secondary": {
+            "value": "{status.focus.surface.btn.brand.secondary}",
+            "type": "color"
+          },
+          "tertiary": {
+            "value": "{status.focus.surface.btn.brand.tertiary}",
+            "type": "color"
+          }
+        },
+        "grey": {
+          "primary": {
+            "value": "{status.focus.surface.btn.grey.primary}",
+            "type": "color"
+          },
+          "secondary": {
+            "value": "{status.focus.surface.btn.grey.secondary}",
+            "type": "color"
+          },
+          "tertiary": {
+            "value": "{status.focus.surface.btn.grey.tertiary}",
+            "type": "color"
+          }
+        },
+        "alert": {
+          "info": {
+            "primary": {
+              "value": "{status.focus.surface.btn.alert.info.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.focus.surface.btn.alert.info.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.focus.surface.btn.alert.info.tertiary}",
+              "type": "color"
+            }
+          },
+          "success": {
+            "primary": {
+              "value": "{status.focus.surface.btn.alert.success.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.focus.surface.btn.alert.success.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.focus.surface.btn.alert.success.tertiary}",
+              "type": "color"
+            }
+          },
+          "warning": {
+            "primary": {
+              "value": "{status.focus.surface.btn.alert.warning.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.focus.surface.btn.alert.warning.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.focus.surface.btn.alert.warning.tertiary}",
+              "type": "color"
+            }
+          },
+          "error": {
+            "primary": {
+              "value": "{status.focus.surface.btn.alert.error.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.focus.surface.btn.alert.error.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.focus.surface.btn.alert.error.tertiary}",
+              "type": "color"
+            }
+          }
+        }
+      },
+      "content": {
+        "brand": {
+          "primary": {
+            "value": "{status.focus.content.btn.brand.primary}",
+            "type": "color"
+          },
+          "secondary": {
+            "value": "{status.focus.content.btn.brand.secondary}",
+            "type": "color"
+          },
+          "tertiary": {
+            "value": "{status.focus.content.btn.brand.tertiary}",
+            "type": "color"
+          }
+        },
+        "grey": {
+          "primary": {
+            "value": "{status.focus.content.btn.grey.primary}",
+            "type": "color"
+          },
+          "secondary": {
+            "value": "{status.focus.content.btn.grey.secondary}",
+            "type": "color"
+          },
+          "tertiary": {
+            "value": "{status.focus.content.btn.grey.tertiary}",
+            "type": "color"
+          }
+        },
+        "alert": {
+          "info": {
+            "primary": {
+              "value": "{status.focus.content.btn.alert.info.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.focus.content.btn.alert.info.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.focus.content.btn.alert.info.tertiary}",
+              "type": "color"
+            }
+          },
+          "success": {
+            "primary": {
+              "value": "{status.focus.content.btn.alert.success.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.focus.content.btn.alert.success.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.focus.content.btn.alert.success.tertiary}",
+              "type": "color"
+            }
+          },
+          "warning": {
+            "primary": {
+              "value": "{status.focus.content.btn.alert.warning.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.focus.content.btn.alert.warning.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.focus.content.btn.alert.warning.tertiary}",
+              "type": "color"
+            }
+          },
+          "error": {
+            "primary": {
+              "value": "{status.focus.content.btn.alert.error.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.focus.content.btn.alert.error.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.focus.content.btn.alert.error.tertiary}",
+              "type": "color"
+            }
+          }
+        },
+        "icon-size": {
+          "value": "{button.focus.icon.icon-size}",
+          "type": "dimension"
+        }
+      },
+      "border": {
+        "brand": {
+          "primary": {
+            "value": "{status.focus.border.btn.brand.primary}",
+            "type": "color"
+          },
+          "secondary": {
+            "value": "{status.focus.border.btn.brand.secondary}",
+            "type": "color"
+          },
+          "tertiary": {
+            "value": "{status.focus.border.btn.brand.tertiary}",
+            "type": "color"
+          }
+        },
+        "grey": {
+          "primary": {
+            "value": "{status.focus.border.btn.grey.primary}",
+            "type": "color"
+          },
+          "secondary": {
+            "value": "{status.focus.border.btn.grey.secondary}",
+            "type": "color"
+          },
+          "tertiary": {
+            "value": "{status.focus.border.btn.grey.tertiary}",
+            "type": "color"
+          }
+        },
+        "alert": {
+          "info": {
+            "primary": {
+              "value": "{status.focus.border.btn.alert.info.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.focus.border.btn.alert.info.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.focus.border.btn.alert.info.tertiary}",
+              "type": "color"
+            }
+          },
+          "success": {
+            "primary": {
+              "value": "{status.focus.border.btn.alert.success.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.focus.border.btn.alert.success.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.focus.border.btn.alert.success.tertiary}",
+              "type": "color"
+            }
+          },
+          "warning": {
+            "primary": {
+              "value": "{status.focus.border.btn.alert.warning.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.focus.border.btn.alert.warning.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.focus.border.btn.alert.warning.tertiary}",
+              "type": "color"
+            }
+          },
+          "error": {
+            "primary": {
+              "value": "{status.focus.border.btn.alert.error.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.focus.border.btn.alert.error.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.focus.border.btn.alert.error.tertiary}",
+              "type": "color"
+            }
+          }
+        },
+        "width": {
+          "value": "{button.focus.border.width}",
+          "type": "dimension"
+        },
+        "radius": {
+          "value": "{button.focus.border.radius}",
+          "type": "dimension"
+        }
+      },
+      "indicator": {
+        "surface": {
+          "brand": {
+            "primary": {
+              "value": "{status.focus.indicator.surface.btn.brand.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.focus.indicator.surface.btn.brand.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.focus.indicator.surface.btn.brand.tertiary}",
+              "type": "color"
+            }
+          },
+          "grey": {
+            "primary": {
+              "value": "{status.focus.indicator.surface.btn.grey.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.focus.indicator.surface.btn.grey.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.focus.indicator.surface.btn.grey.tertiary}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "primary": {
+                "value": "{status.focus.indicator.surface.btn.alert.info.primary}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{status.focus.indicator.surface.btn.alert.info.secondary}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{status.focus.indicator.surface.btn.alert.info.tertiary}",
+                "type": "color"
+              }
+            },
+            "success": {
+              "primary": {
+                "value": "{status.focus.indicator.surface.btn.alert.success.primary}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{status.focus.indicator.surface.btn.alert.success.secondary}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{status.focus.indicator.surface.btn.alert.success.tertiary}",
+                "type": "color"
+              }
+            },
+            "warning": {
+              "primary": {
+                "value": "{status.focus.indicator.surface.btn.alert.warning.primary}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{status.focus.indicator.surface.btn.alert.warning.secondary}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{status.focus.indicator.surface.btn.alert.warning.tertiary}",
+                "type": "color"
+              }
+            },
+            "error": {
+              "primary": {
+                "value": "{status.focus.indicator.surface.btn.alert.error.primary}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{status.focus.indicator.surface.btn.alert.error.secondary}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{status.focus.indicator.surface.btn.alert.error.tertiary}",
+                "type": "color"
+              }
+            }
+          }
+        },
+        "border": {
+          "brand": {
+            "primary": {
+              "value": "{status.focus.indicator.border.btn.brand.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.focus.indicator.border.btn.brand.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.focus.indicator.border.btn.brand.tertiary}",
+              "type": "color"
+            }
+          },
+          "grey": {
+            "primary": {
+              "value": "{status.focus.indicator.border.btn.grey.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.focus.indicator.border.btn.grey.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.focus.indicator.border.btn.grey.tertiary}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "primary": {
+                "value": "{status.focus.indicator.border.btn.alert.info.primary}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{status.focus.indicator.border.btn.alert.info.secondary}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{status.focus.indicator.border.btn.alert.info.tertiary}",
+                "type": "color"
+              }
+            },
+            "success": {
+              "primary": {
+                "value": "{status.focus.indicator.border.btn.alert.success.primary}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{status.focus.indicator.border.btn.alert.success.secondary}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{status.focus.indicator.border.btn.alert.success.tertiary}",
+                "type": "color"
+              }
+            },
+            "warning": {
+              "primary": {
+                "value": "{status.focus.indicator.border.btn.alert.warning.primary}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{status.focus.indicator.border.btn.alert.warning.secondary}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{status.focus.indicator.border.btn.alert.warning.tertiary}",
+                "type": "color"
+              }
+            },
+            "error": {
+              "primary": {
+                "value": "{status.focus.indicator.border.btn.alert.error.primary}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{status.focus.indicator.border.btn.alert.error.secondary}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{status.focus.indicator.border.btn.alert.error.tertiary}",
+                "type": "color"
+              }
+            }
+          },
+          "width": {
+            "value": "{button.focus.indicator.border.width}",
+            "type": "dimension"
+          },
+          "radius": {
+            "value": "{button.hover.indicator.border.radius}",
+            "type": "dimension"
+          }
+        },
+        "space": {
+          "start-x": {
+            "value": "{button.focus.indicator.padding.start-x}",
+            "type": "dimension"
+          },
+          "top-y": {
+            "value": "{button.focus.indicator.padding.p-y}",
+            "type": "dimension"
+          },
+          "end-x": {
+            "value": "{button.focus.indicator.padding.end-x}",
+            "type": "dimension"
+          },
+          "bottom-y": {
+            "value": "{button.focus.indicator.padding.p-y}",
+            "type": "dimension"
+          }
+        }
+      },
+      "weight": {
+        "font-weight": {
+          "value": "{button.focus.text.font-weight}",
+          "type": "text"
+        }
+      },
+      "space": {
+        "p-x": {
+          "value": "{button.focus.space.p-x}",
+          "type": "dimension"
+        },
+        "p-y": {
+          "value": "{button.focus.space.p-y}",
+          "type": "dimension"
+        },
+        "g-x": {
+          "value": "{button.focus.space.g-x}",
+          "type": "dimension"
+        },
+        "g-y": {
+          "value": "{button.focus.space.g-y}",
+          "type": "dimension"
+        }
+      }
+    },
+    "is-default": {
+      "value": "false",
+      "type": "boolean"
+    },
+    "is-hover": {
+      "value": "false",
+      "type": "boolean"
+    },
+    "is-focus": {
+      "value": "true",
+      "type": "boolean"
+    },
+    "is-active": {
+      "value": "false",
+      "type": "boolean"
+    }
+  },
+  "status/active": {
+    "dep*": {
+      "alert": {
+        "error": {
+          "value": "{contrast-shades.grey.grey-low}",
+          "type": "color"
+        },
+        "warning": {
+          "value": "{contrast-shades.grey.grey-low}",
+          "type": "color"
+        },
+        "notification": {
+          "value": "{contrast-shades.grey.grey-low}",
+          "type": "color"
+        },
+        "success": {
+          "value": "{contrast-shades.grey.grey-low}",
+          "type": "color"
+        }
+      },
+      "content": {
+        "link": {
+          "default": {
+            "value": "{dep*.alert.error}",
+            "type": "color"
+          },
+          "focus": {
+            "value": "{dep*.alert.error}",
+            "type": "color"
+          },
+          "active": {
+            "value": "{dep*.alert.error}",
+            "type": "color"
+          },
+          "visited": {
+            "value": "{dynamic.text.visited|disabled.link.visited}",
+            "type": "color"
+          },
+          "disabled": {
+            "value": "{dynamic.text.visited|disabled.link.disabled}",
+            "type": "color"
+          }
+        },
+        "alert": {
+          "error": {
+            "value": "{dynamic.text.hover.alert.error}",
+            "type": "color"
+          },
+          "warning": {
+            "value": "{dynamic.text.hover.alert.warning}",
+            "type": "color"
+          },
+          "notification": {
+            "value": "{dynamic.text.hover.alert.notification}",
+            "type": "color"
+          },
+          "success": {
+            "value": "{dynamic.text.hover.alert.success}",
+            "type": "color"
+          }
+        },
+        "btn": {
+          "primary": {
+            "brand": {
+              "value": "{contrast-shades.inv.brand.ne-3 2}",
+              "type": "color"
+            },
+            "gray": {
+              "value": "{contrast-shades.grey.grey-low}",
+              "type": "color"
+            }
+          },
+          "secondary": {
+            "brand": {
+              "value": "{contrast-shades.inv.brand.ne-3 2}",
+              "type": "color"
+            },
+            "gray": {
+              "value": "{contrast-shades.grey.grey-low}",
+              "type": "color"
+            }
+          },
+          "tertiary": {
+            "brand": {
+              "value": "{contrast-shades.inv.brand.ne-3 2}",
+              "type": "color"
+            },
+            "gray": {
+              "value": "{contrast-shades.grey.grey-low}",
+              "type": "color"
+            }
+          }
+        }
+      },
+      "link": {
+        "default": {
+          "value": "{dep*.alert.error}",
+          "type": "color"
+        },
+        "active": {
+          "value": "{dep*.alert.error}",
+          "type": "color"
+        },
+        "visited": {
+          "value": "{dynamic.background.visited|disabled.link.visited}",
+          "type": "color"
+        },
+        "disabled": {
+          "value": "{dynamic.background.visited|disabled.link.disabled}",
+          "type": "color"
+        },
+        "focus": {
+          "value": "{dep*.alert.error}",
+          "type": "color"
+        }
+      },
+      "border": {
+        "link": {
+          "default": {
+            "value": "{dep*.border.alert.error}",
+            "type": "color"
+          },
+          "active": {
+            "value": "{dep*.border.alert.error}",
+            "type": "color"
+          },
+          "visited": {
+            "value": "{dynamic.border.visited|disabled.link.visited}",
+            "type": "color"
+          },
+          "disabled": {
+            "value": "{dynamic.border.visited|disabled.link.disabled}",
+            "type": "color"
+          },
+          "focus": {
+            "value": "{dep*.border.alert.error}",
+            "type": "color"
+          }
+        },
+        "alert": {
+          "error": {
+            "value": "{dynamic.background.focus|active.alert.error}",
+            "type": "color"
+          },
+          "warning": {
+            "value": "{dynamic.background.focus|active.alert.warning}",
+            "type": "color"
+          },
+          "notification": {
+            "value": "{dynamic.background.focus|active.alert.notification}",
+            "type": "color"
+          },
+          "success": {
+            "value": "{dynamic.background.focus|active.alert.success}",
+            "type": "color"
+          }
+        },
+        "btn": {
+          "primary": {
+            "brand": {
+              "value": "{contrast-shades.inv.brand.ne-3 2}",
+              "type": "color"
+            },
+            "grey": {
+              "value": "{contrast-shades.inv.grey.g-2}",
+              "type": "color"
+            }
+          },
+          "secondary": {
+            "brand": {
+              "value": "{contrast-shades.inv.brand.ne-3 2}",
+              "type": "color"
+            },
+            "gray": {
+              "value": "{contrast-shades.grey.grey-low}",
+              "type": "color"
+            }
+          },
+          "tertiary": {
+            "brand": {
+              "value": "{contrast-shades.inv.brand.ne-1 2}",
+              "type": "color"
+            },
+            "gray": {
+              "value": "{contrast-shades.inv.grey.g-1}",
+              "type": "color"
+            }
+          }
+        }
+      },
+      "btn": {
+        "primary": {
+          "brand": {
+            "value": "{contrast-shades.inv.grey.g-2}",
+            "type": "color"
+          },
+          "gray": {
+            "value": "{contrast-shades.inv.grey.g-1}",
+            "type": "color"
+          }
+        },
+        "secondary": {
+          "gray": {
+            "value": "{contrast-shades.inv.grey.g-1}",
+            "type": "color"
+          },
+          "brand": {
+            "value": "{contrast-shades.inv.brand.ne-1 2}",
+            "type": "color"
+          }
+        },
+        "tertiary": {
+          "brand": {
+            "value": "{contrast-shades.inv.brand.ne-1 2}",
+            "type": "color"
+          },
+          "gray": {
+            "value": "{contrast-shades.inv.grey.g-1}",
+            "type": "color"
+          }
+        }
+      }
+    },
+    "btn": {
+      "surface": {
+        "brand": {
+          "primary": {
+            "value": "{status.active.surface.btn.brand.primary}",
+            "type": "color"
+          },
+          "secondary": {
+            "value": "{status.active.surface.btn.brand.secondary}",
+            "type": "color"
+          },
+          "tertiary": {
+            "value": "{status.active.surface.btn.brand.tertiary}",
+            "type": "color"
+          }
+        },
+        "grey": {
+          "primary": {
+            "value": "{status.active.surface.btn.grey.primary}",
+            "type": "color"
+          },
+          "secondary": {
+            "value": "{status.active.surface.btn.grey.secondary}",
+            "type": "color"
+          },
+          "tertiary": {
+            "value": "{status.active.surface.btn.grey.tertiary}",
+            "type": "color"
+          }
+        },
+        "alert": {
+          "info": {
+            "primary": {
+              "value": "{status.active.surface.btn.alert.info.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.active.surface.btn.alert.info.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.active.surface.btn.alert.info.tertiary}",
+              "type": "color"
+            }
+          },
+          "success": {
+            "primary": {
+              "value": "{status.active.surface.btn.alert.success.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.active.surface.btn.alert.success.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.active.surface.btn.alert.success.tertiary}",
+              "type": "color"
+            }
+          },
+          "warning": {
+            "primary": {
+              "value": "{status.active.surface.btn.alert.warning.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.active.surface.btn.alert.warning.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.active.surface.btn.alert.warning.tertiary}",
+              "type": "color"
+            }
+          },
+          "error": {
+            "primary": {
+              "value": "{status.active.surface.btn.alert.error.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.active.surface.btn.alert.error.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.active.surface.btn.alert.error.tertiary}",
+              "type": "color"
+            }
+          }
+        }
+      },
+      "content": {
+        "brand": {
+          "primary": {
+            "value": "{status.active.content.btn.brand.primary}",
+            "type": "color"
+          },
+          "secondary": {
+            "value": "{status.active.content.btn.brand.secondary}",
+            "type": "color"
+          },
+          "tertiary": {
+            "value": "{status.active.content.btn.brand.tertiary}",
+            "type": "color"
+          }
+        },
+        "grey": {
+          "primary": {
+            "value": "{status.active.content.btn.grey.primary}",
+            "type": "color"
+          },
+          "secondary": {
+            "value": "{status.active.content.btn.grey.secondary}",
+            "type": "color"
+          },
+          "tertiary": {
+            "value": "{status.active.content.btn.grey.tertiary}",
+            "type": "color"
+          }
+        },
+        "alert": {
+          "info": {
+            "primary": {
+              "value": "{status.active.content.btn.alert.info.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.active.content.btn.alert.info.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.active.content.btn.alert.info.tertiary}",
+              "type": "color"
+            }
+          },
+          "success": {
+            "primary": {
+              "value": "{status.active.content.btn.alert.success.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.active.content.btn.alert.success.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.active.content.btn.alert.success.tertiary}",
+              "type": "color"
+            }
+          },
+          "warning": {
+            "primary": {
+              "value": "{status.active.content.btn.alert.warning.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.active.content.btn.alert.warning.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.active.content.btn.alert.warning.tertiary}",
+              "type": "color"
+            }
+          },
+          "error": {
+            "primary": {
+              "value": "{status.active.content.btn.alert.error.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.active.content.btn.alert.error.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.active.content.btn.alert.error.tertiary}",
+              "type": "color"
+            }
+          }
+        },
+        "icon-size": {
+          "value": "{button.active.icon.icon-size}",
+          "type": "dimension"
+        }
+      },
+      "border": {
+        "brand": {
+          "primary": {
+            "value": "{status.active.border.btn.brand.primary}",
+            "type": "color"
+          },
+          "secondary": {
+            "value": "{status.active.border.btn.brand.secondary}",
+            "type": "color"
+          },
+          "tertiary": {
+            "value": "{status.active.border.btn.brand.tertiary}",
+            "type": "color"
+          }
+        },
+        "grey": {
+          "primary": {
+            "value": "{status.active.border.btn.grey.primary}",
+            "type": "color"
+          },
+          "secondary": {
+            "value": "{status.active.border.btn.grey.secondary}",
+            "type": "color"
+          },
+          "tertiary": {
+            "value": "{status.active.border.btn.grey.tertiary}",
+            "type": "color"
+          }
+        },
+        "alert": {
+          "info": {
+            "primary": {
+              "value": "{status.active.border.btn.alert.info.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.active.border.btn.alert.info.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.active.border.btn.alert.info.tertiary}",
+              "type": "color"
+            }
+          },
+          "success": {
+            "primary": {
+              "value": "{status.active.border.btn.alert.success.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.active.border.btn.alert.success.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.active.border.btn.alert.success.tertiary}",
+              "type": "color"
+            }
+          },
+          "warning": {
+            "primary": {
+              "value": "{status.active.border.btn.alert.warning.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.active.border.btn.alert.warning.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.active.border.btn.alert.warning.tertiary}",
+              "type": "color"
+            }
+          },
+          "error": {
+            "primary": {
+              "value": "{status.active.border.btn.alert.error.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.active.border.btn.alert.error.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.active.border.btn.alert.error.tertiary}",
+              "type": "color"
+            }
+          }
+        },
+        "width": {
+          "value": "{button.active.border.width}",
+          "type": "dimension"
+        },
+        "radius": {
+          "value": "{button.active.border.radius}",
+          "type": "dimension"
+        }
+      },
+      "indicator": {
+        "surface": {
+          "brand": {
+            "primary": {
+              "value": "{status.active.indicator.surface.btn.brand.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.active.indicator.surface.btn.brand.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.active.indicator.surface.btn.brand.tertiary}",
+              "type": "color"
+            }
+          },
+          "grey": {
+            "primary": {
+              "value": "{status.active.indicator.surface.btn.grey.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.active.indicator.surface.btn.grey.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.active.indicator.surface.btn.grey.tertiary}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "primary": {
+                "value": "{status.active.indicator.surface.btn.alert.info.primary}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{status.active.indicator.surface.btn.alert.info.secondary}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{status.active.indicator.surface.btn.alert.info.tertiary}",
+                "type": "color"
+              }
+            },
+            "success": {
+              "primary": {
+                "value": "{status.active.indicator.surface.btn.alert.success.primary}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{status.active.indicator.surface.btn.alert.success.secondary}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{status.active.indicator.surface.btn.alert.success.tertiary}",
+                "type": "color"
+              }
+            },
+            "warning": {
+              "primary": {
+                "value": "{status.active.indicator.surface.btn.alert.warning.primary}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{status.active.indicator.surface.btn.alert.warning.secondary}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{status.active.indicator.surface.btn.alert.warning.tertiary}",
+                "type": "color"
+              }
+            },
+            "error": {
+              "primary": {
+                "value": "{status.active.indicator.surface.btn.alert.error.primary}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{status.active.indicator.surface.btn.alert.error.secondary}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{status.active.indicator.surface.btn.alert.error.tertiary}",
+                "type": "color"
+              }
+            }
+          }
+        },
+        "border": {
+          "brand": {
+            "primary": {
+              "value": "{status.active.indicator.border.btn.brand.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.active.indicator.border.btn.brand.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.active.indicator.border.btn.brand.tertiary}",
+              "type": "color"
+            }
+          },
+          "grey": {
+            "primary": {
+              "value": "{status.active.indicator.border.btn.grey.primary}",
+              "type": "color"
+            },
+            "secondary": {
+              "value": "{status.active.indicator.border.btn.grey.secondary}",
+              "type": "color"
+            },
+            "tertiary": {
+              "value": "{status.active.indicator.border.btn.grey.tertiary}",
+              "type": "color"
+            }
+          },
+          "alert": {
+            "info": {
+              "primary": {
+                "value": "{status.active.indicator.border.btn.alert.info.primary}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{status.active.indicator.border.btn.alert.info.secondary}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{status.active.indicator.border.btn.alert.info.tertiary}",
+                "type": "color"
+              }
+            },
+            "success": {
+              "primary": {
+                "value": "{status.active.indicator.border.btn.alert.success.primary}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{status.active.indicator.border.btn.alert.success.secondary}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{status.active.indicator.border.btn.alert.success.tertiary}",
+                "type": "color"
+              }
+            },
+            "warning": {
+              "primary": {
+                "value": "{status.active.indicator.border.btn.alert.warning.primary}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{status.active.indicator.border.btn.alert.warning.secondary}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{status.active.indicator.border.btn.alert.warning.tertiary}",
+                "type": "color"
+              }
+            },
+            "error": {
+              "primary": {
+                "value": "{status.active.indicator.border.btn.alert.error.primary}",
+                "type": "color"
+              },
+              "secondary": {
+                "value": "{status.active.indicator.border.btn.alert.error.secondary}",
+                "type": "color"
+              },
+              "tertiary": {
+                "value": "{status.active.indicator.border.btn.alert.error.tertiary}",
+                "type": "color"
+              }
+            }
+          },
+          "width": {
+            "value": "{button.active.indicator.border.width}",
+            "type": "dimension"
+          },
+          "radius": {
+            "value": "{button.hover.indicator.border.radius}",
+            "type": "dimension"
+          }
+        },
+        "space": {
+          "start-x": {
+            "value": "{button.active.indicator.padding.start-x}",
+            "type": "dimension"
+          },
+          "top-y": {
+            "value": "{button.active.indicator.padding.top-y}",
+            "type": "dimension"
+          },
+          "end-x": {
+            "value": "{button.active.indicator.padding.end-x}",
+            "type": "dimension"
+          },
+          "bottom-y": {
+            "value": "{button.active.indicator.padding.bottom-y}",
+            "type": "dimension"
+          }
+        }
+      },
+      "weight": {
+        "font-weight": {
+          "value": "{button.active.text.font-weight}",
+          "type": "text"
+        }
+      },
+      "space": {
+        "p-x": {
+          "value": "{button.active.space.p-x}",
+          "type": "dimension"
+        },
+        "p-y": {
+          "value": "{button.active.space.p-y}",
+          "type": "dimension"
+        },
+        "g-x": {
+          "value": "{button.active.space.g-x}",
+          "type": "dimension"
+        },
+        "g-y": {
+          "value": "{button.active.space.g-y}",
+          "type": "dimension"
+        }
+      }
+    },
+    "is-default": {
+      "value": "false",
+      "type": "boolean"
+    },
+    "is-hover": {
+      "value": "false",
+      "type": "boolean"
+    },
+    "is-focus": {
+      "value": "false",
+      "type": "boolean"
+    },
+    "is-active": {
+      "value": "true",
+      "type": "boolean"
+    }
+  },
+  "color-primitive/color-value": {
+    "100%": {
+      "brand": {
+        "uranus": {
+          "50": {
+            "value": "#f2f9fb",
+            "type": "color"
+          },
+          "100": {
+            "value": "#d8ecf3",
+            "type": "color"
+          },
+          "200": {
+            "value": "#c5e3ed",
+            "type": "color"
+          },
+          "300": {
+            "value": "#abd7e4",
+            "type": "color"
+          },
+          "400": {
+            "value": "#9acfdf",
+            "type": "color"
+          },
+          "500": {
+            "value": "#81c3d7",
+            "type": "color"
+          },
+          "600": {
+            "value": "#75b1c4",
+            "type": "color"
+          },
+          "700": {
+            "value": "#5c8a99",
+            "type": "color"
+          },
+          "800": {
+            "value": "#476b76",
+            "type": "color"
+          },
+          "900": {
+            "value": "#36525a",
+            "type": "color"
+          }
+        },
+        "jupiter": {
+          "50": {
+            "value": "#fff2e7",
+            "type": "color"
+          },
+          "100": {
+            "value": "#ffd7b4",
+            "type": "color"
+          },
+          "200": {
+            "value": "#ffc490",
+            "type": "color"
+          },
+          "300": {
+            "value": "#ffa95e",
+            "type": "color"
+          },
+          "400": {
+            "value": "#ff993e",
+            "type": "color"
+          },
+          "500": {
+            "value": "#ff7f0e",
+            "type": "color"
+          },
+          "600": {
+            "value": "#e8740d",
+            "type": "color"
+          },
+          "700": {
+            "value": "#b55a0a",
+            "type": "color"
+          },
+          "800": {
+            "value": "#8c4608",
+            "type": "color"
+          },
+          "900": {
+            "value": "#6b3506",
+            "type": "color"
+          }
+        },
+        "neptune": {
+          "50": {
+            "value": "#ebf2f6",
+            "type": "color"
+          },
+          "100": {
+            "value": "#c2d6e3",
+            "type": "color"
+          },
+          "200": {
+            "value": "#a4c3d6",
+            "type": "color"
+          },
+          "300": {
+            "value": "#7ba7c3",
+            "type": "color"
+          },
+          "400": {
+            "value": "#6196b7",
+            "type": "color"
+          },
+          "500": {
+            "value": "#3a7ca5",
+            "type": "color"
+          },
+          "600": {
+            "value": "#357196",
+            "type": "color"
+          },
+          "700": {
+            "value": "#295875",
+            "type": "color"
+          },
+          "800": {
+            "value": "#20445b",
+            "type": "color"
+          },
+          "900": {
+            "value": "#183445",
+            "type": "color"
+          }
+        },
+        "saturn": {
+          "50": {
+            "value": "#fff7e6",
+            "type": "color"
+          },
+          "100": {
+            "value": "#ffe5b0",
+            "type": "color"
+          },
+          "200": {
+            "value": "#ffd88a",
+            "type": "color"
+          },
+          "300": {
+            "value": "#ffc754",
+            "type": "color"
+          },
+          "400": {
+            "value": "#ffbc33",
+            "type": "color"
+          },
+          "500": {
+            "value": "#ffab00",
+            "type": "color"
+          },
+          "600": {
+            "value": "#e89c00",
+            "type": "color"
+          },
+          "700": {
+            "value": "#b57900",
+            "type": "color"
+          },
+          "800": {
+            "value": "#8c5e00",
+            "type": "color"
+          },
+          "900": {
+            "value": "#6b4800",
+            "type": "color"
+          }
+        },
+        "cosmic": {
+          "50": {
+            "value": "#ebedf7",
+            "type": "color"
+          },
+          "100": {
+            "value": "#c2c8e5",
+            "type": "color"
+          },
+          "200": {
+            "value": "#a4add9",
+            "type": "color"
+          },
+          "300": {
+            "value": "#7a87c7",
+            "type": "color"
+          },
+          "400": {
+            "value": "#6170bd",
+            "type": "color"
+          },
+          "500": {
+            "value": "#394cac",
+            "type": "color"
+          },
+          "600": {
+            "value": "#34459d",
+            "type": "color"
+          },
+          "700": {
+            "value": "#28367a",
+            "type": "color"
+          },
+          "800": {
+            "value": "#1f2a5f",
+            "type": "color"
+          },
+          "900": {
+            "value": "#182048",
+            "type": "color"
+          }
+        },
+        "nebula": {
+          "50": {
+            "value": "#f1ebf7",
+            "type": "color"
+          },
+          "100": {
+            "value": "#cdb7e1",
+            "type": "color"
+          },
+          "200": {
+            "value": "#bd9cde",
+            "type": "color"
+          },
+          "300": {
+            "value": "#a681ca",
+            "type": "color"
+          },
+          "400": {
+            "value": "#996fc3",
+            "type": "color"
+          },
+          "500": {
+            "value": "#7339ac",
+            "type": "color"
+          },
+          "600": {
+            "value": "#69349d",
+            "type": "color"
+          },
+          "700": {
+            "value": "#52287a",
+            "type": "color"
+          },
+          "800": {
+            "value": "#3f1f5f",
+            "type": "color"
+          },
+          "900": {
+            "value": "#301848",
+            "type": "color"
+          }
+        }
+      },
+      "grey": {
+        "50": {
+          "value": "#ffffff",
+          "type": "color"
+        },
+        "100": {
+          "value": "#f0edee",
+          "type": "color"
+        },
+        "200": {
+          "value": "#dad8d9",
+          "type": "color"
+        },
+        "300": {
+          "value": "#b9b9b9",
+          "type": "color"
+        },
+        "400": {
+          "value": "#979797",
+          "type": "color"
+        },
+        "500": {
+          "value": "#676767",
+          "type": "color"
+        },
+        "600": {
+          "value": "#494949",
+          "type": "color"
+        },
+        "700": {
+          "value": "#292929",
+          "type": "color"
+        },
+        "800": {
+          "value": "#1c1c1c",
+          "type": "color"
+        },
+        "900": {
+          "value": "#000000",
+          "type": "color"
+        }
+      },
+      "alert": {
+        "error": {
+          "50": {
+            "value": "#f9ecec",
+            "type": "color"
+          },
+          "100": {
+            "value": "#ebc4c4",
+            "type": "color"
+          },
+          "200": {
+            "value": "#e29898",
+            "type": "color"
+          },
+          "300": {
+            "value": "#d47f7f",
+            "type": "color"
+          },
+          "400": {
+            "value": "#cc6666",
+            "type": "color"
+          },
+          "500": {
+            "value": "#be5555",
+            "type": "color"
+          },
+          "600": {
+            "value": "#ae3a3a",
+            "type": "color"
+          },
+          "700": {
+            "value": "#882d2d",
+            "type": "color"
+          },
+          "800": {
+            "value": "#692323",
+            "type": "color"
+          },
+          "900": {
+            "value": "#501b1b",
+            "type": "color"
+          }
+        },
+        "info": {
+          "50": {
+            "value": "#eaf8f6",
+            "type": "color"
+          },
+          "100": {
+            "value": "#bee8e4",
+            "type": "color"
+          },
+          "200": {
+            "value": "#9fddd7",
+            "type": "color"
+          },
+          "300": {
+            "value": "#73cec5",
+            "type": "color"
+          },
+          "400": {
+            "value": "#58c5ba",
+            "type": "color"
+          },
+          "500": {
+            "value": "#2eb6a9",
+            "type": "color"
+          },
+          "600": {
+            "value": "#279b8f",
+            "type": "color"
+          },
+          "700": {
+            "value": "#19635d",
+            "type": "color"
+          },
+          "800": {
+            "value": "#114541",
+            "type": "color"
+          },
+          "900": {
+            "value": "#0c312e",
+            "type": "color"
+          }
+        },
+        "success": {
+          "50": {
+            "value": "#ecf9ed",
+            "type": "color"
+          },
+          "100": {
+            "value": "#c4ebc6",
+            "type": "color"
+          },
+          "200": {
+            "value": "#a7e2aa",
+            "type": "color"
+          },
+          "300": {
+            "value": "#7fd483",
+            "type": "color"
+          },
+          "400": {
+            "value": "#66cc6b",
+            "type": "color"
+          },
+          "500": {
+            "value": "#3aae40",
+            "type": "color"
+          },
+          "600": {
+            "value": "#2d8832",
+            "type": "color"
+          },
+          "700": {
+            "value": "#226626",
+            "type": "color"
+          },
+          "800": {
+            "value": "#1b501d",
+            "type": "color"
+          },
+          "900": {
+            "value": "#153d16",
+            "type": "color"
+          }
+        },
+        "warning": {
+          "50": {
+            "value": "#fdfae7",
+            "type": "color"
+          },
+          "100": {
+            "value": "#f8efb3",
+            "type": "color"
+          },
+          "200": {
+            "value": "#f5e78e",
+            "type": "color"
+          },
+          "300": {
+            "value": "#f0dc5b",
+            "type": "color"
+          },
+          "400": {
+            "value": "#edd53b",
+            "type": "color"
+          },
+          "500": {
+            "value": "#e9cb0a",
+            "type": "color"
+          },
+          "600": {
+            "value": "#d4b909",
+            "type": "color"
+          },
+          "700": {
+            "value": "#6b5d05",
+            "type": "color"
+          },
+          "800": {
+            "value": "#524703",
+            "type": "color"
+          },
+          "900": {
+            "value": "#332c02",
+            "type": "color"
+          }
+        }
+      }
+    },
+    "5%": {
+      "brand": {
+        "uranus": {
+          "50": {
+            "value": "#f2f9fb0d",
+            "type": "color"
+          },
+          "100": {
+            "value": "#d8ecf30d",
+            "type": "color"
+          },
+          "200": {
+            "value": "#c5e3ed0d",
+            "type": "color"
+          },
+          "300": {
+            "value": "#abd7e40d",
+            "type": "color"
+          },
+          "400": {
+            "value": "#9acfdf0d",
+            "type": "color"
+          },
+          "500": {
+            "value": "#81c3d70d",
+            "type": "color"
+          },
+          "600": {
+            "value": "#75b1c40d",
+            "type": "color"
+          },
+          "700": {
+            "value": "#5c8a990d",
+            "type": "color"
+          },
+          "800": {
+            "value": "#476b760d",
+            "type": "color"
+          },
+          "900": {
+            "value": "#36525a0d",
+            "type": "color"
+          }
+        },
+        "jupiter": {
+          "50": {
+            "value": "#fff2e70d",
+            "type": "color"
+          },
+          "100": {
+            "value": "#ffd7b40d",
+            "type": "color"
+          },
+          "200": {
+            "value": "#ffc4900d",
+            "type": "color"
+          },
+          "300": {
+            "value": "#ffa95e0d",
+            "type": "color"
+          },
+          "400": {
+            "value": "#ff993e0d",
+            "type": "color"
+          },
+          "500": {
+            "value": "#ff7f0e0d",
+            "type": "color"
+          },
+          "600": {
+            "value": "#e8740d0d",
+            "type": "color"
+          },
+          "700": {
+            "value": "#b55a0a0d",
+            "type": "color"
+          },
+          "800": {
+            "value": "#8c46080d",
+            "type": "color"
+          },
+          "900": {
+            "value": "#6b35060d",
+            "type": "color"
+          }
+        },
+        "neptune": {
+          "50": {
+            "value": "#ebf2f60d",
+            "type": "color"
+          },
+          "100": {
+            "value": "#c2d6e30d",
+            "type": "color"
+          },
+          "200": {
+            "value": "#a4c3d60d",
+            "type": "color"
+          },
+          "300": {
+            "value": "#7ba7c30d",
+            "type": "color"
+          },
+          "400": {
+            "value": "#6196b70d",
+            "type": "color"
+          },
+          "500": {
+            "value": "#3a7ca50d",
+            "type": "color"
+          },
+          "600": {
+            "value": "#3571960d",
+            "type": "color"
+          },
+          "700": {
+            "value": "#2958750d",
+            "type": "color"
+          },
+          "800": {
+            "value": "#20445b0d",
+            "type": "color"
+          },
+          "900": {
+            "value": "#1834450d",
+            "type": "color"
+          }
+        },
+        "saturn": {
+          "50": {
+            "value": "#fff7e60d",
+            "type": "color"
+          },
+          "100": {
+            "value": "#ffe5b00d",
+            "type": "color"
+          },
+          "200": {
+            "value": "#ffd88a0d",
+            "type": "color"
+          },
+          "300": {
+            "value": "#ffc7540d",
+            "type": "color"
+          },
+          "400": {
+            "value": "#ffbc330d",
+            "type": "color"
+          },
+          "500": {
+            "value": "#ffab000d",
+            "type": "color"
+          },
+          "600": {
+            "value": "#e89c000d",
+            "type": "color"
+          },
+          "700": {
+            "value": "#b579000d",
+            "type": "color"
+          },
+          "800": {
+            "value": "#8c5e000d",
+            "type": "color"
+          },
+          "900": {
+            "value": "#6b48000d",
+            "type": "color"
+          }
+        },
+        "cosmic": {
+          "50": {
+            "value": "#ebedf70d",
+            "type": "color"
+          },
+          "100": {
+            "value": "#c2c8e50d",
+            "type": "color"
+          },
+          "200": {
+            "value": "#a4add90d",
+            "type": "color"
+          },
+          "300": {
+            "value": "#7a87c70d",
+            "type": "color"
+          },
+          "400": {
+            "value": "#6170bd0d",
+            "type": "color"
+          },
+          "500": {
+            "value": "#394cac0d",
+            "type": "color"
+          },
+          "600": {
+            "value": "#34459d0d",
+            "type": "color"
+          },
+          "700": {
+            "value": "#28367a0d",
+            "type": "color"
+          },
+          "800": {
+            "value": "#1f2a5f0d",
+            "type": "color"
+          },
+          "900": {
+            "value": "#1820480d",
+            "type": "color"
+          }
+        },
+        "nebula": {
+          "50": {
+            "value": "#f1ebf70d",
+            "type": "color"
+          },
+          "100": {
+            "value": "#d4c2e50d",
+            "type": "color"
+          },
+          "200": {
+            "value": "#bfa4d90d",
+            "type": "color"
+          },
+          "300": {
+            "value": "#a17ac70d",
+            "type": "color"
+          },
+          "400": {
+            "value": "#8f61bd0d",
+            "type": "color"
+          },
+          "500": {
+            "value": "#7339ac0d",
+            "type": "color"
+          },
+          "600": {
+            "value": "#69349d0d",
+            "type": "color"
+          },
+          "700": {
+            "value": "#52287a0d",
+            "type": "color"
+          },
+          "800": {
+            "value": "#3f1f5f0d",
+            "type": "color"
+          },
+          "900": {
+            "value": "#3018480d",
+            "type": "color"
+          }
+        },
+        "00": {
+          "value": "#ffffff",
+          "type": "color"
+        }
+      },
+      "grey": {
+        "50": {
+          "value": "#ffffff0d",
+          "type": "color"
+        },
+        "100": {
+          "value": "#f0edee0d",
+          "type": "color"
+        },
+        "200": {
+          "value": "#dad8d90d",
+          "type": "color"
+        },
+        "300": {
+          "value": "#b9b9b90d",
+          "type": "color"
+        },
+        "400": {
+          "value": "#9797970d",
+          "type": "color"
+        },
+        "500": {
+          "value": "#6767670d",
+          "type": "color"
+        },
+        "600": {
+          "value": "#4949490d",
+          "type": "color"
+        },
+        "700": {
+          "value": "#3030300d",
+          "type": "color"
+        },
+        "800": {
+          "value": "#1c1c1c0d",
+          "type": "color"
+        },
+        "900": {
+          "value": "#0000000d",
+          "type": "color"
+        }
+      },
+      "alert": {
+        "error": {
+          "50": {
+            "value": "#f9ecec0d",
+            "type": "color"
+          },
+          "100": {
+            "value": "#ebc4c40d",
+            "type": "color"
+          },
+          "300": {
+            "value": "#d47f7f0d",
+            "type": "color"
+          },
+          "400": {
+            "value": "#cc66660d",
+            "type": "color"
+          },
+          "500": {
+            "value": "#bf40400d",
+            "type": "color"
+          },
+          "600": {
+            "value": "#ae3a3a0d",
+            "type": "color"
+          },
+          "700": {
+            "value": "#882d2d0d",
+            "type": "color"
+          },
+          "800": {
+            "value": "#6923230d",
+            "type": "color"
+          },
+          "900": {
+            "value": "#501b1b0d",
+            "type": "color"
+          }
+        },
+        "info": {
+          "50": {
+            "value": "#eaf8f60d",
+            "type": "color"
+          },
+          "100": {
+            "value": "#bee8e40d",
+            "type": "color"
+          },
+          "300": {
+            "value": "#73cec50d",
+            "type": "color"
+          },
+          "400": {
+            "value": "#58c5ba0d",
+            "type": "color"
+          },
+          "500": {
+            "value": "#2eb6a90d",
+            "type": "color"
+          },
+          "600": {
+            "value": "#2aa69a0d",
+            "type": "color"
+          },
+          "700": {
+            "value": "#2181780d",
+            "type": "color"
+          },
+          "800": {
+            "value": "#1145410d",
+            "type": "color"
+          },
+          "900": {
+            "value": "#134c470d",
+            "type": "color"
+          }
+        },
+        "success": {
+          "50": {
+            "value": "#ecf9ed0d",
+            "type": "color"
+          },
+          "100": {
+            "value": "#c4ebc60d",
+            "type": "color"
+          },
+          "200": {
+            "value": "#a7e2aa0d",
+            "type": "color"
+          },
+          "300": {
+            "value": "#7fd4830d",
+            "type": "color"
+          },
+          "400": {
+            "value": "#66cc6b0d",
+            "type": "color"
+          },
+          "500": {
+            "value": "#3aae400d",
+            "type": "color"
+          },
+          "600": {
+            "value": "#2d88320d",
+            "type": "color"
+          },
+          "700": {
+            "value": "#2369270d",
+            "type": "color"
+          },
+          "800": {
+            "value": "#1b501d0d",
+            "type": "color"
+          },
+          "900": {
+            "value": "#153d160d",
+            "type": "color"
+          }
+        },
+        "warning": {
+          "50": {
+            "value": "#fdfae70d",
+            "type": "color"
+          },
+          "100": {
+            "value": "#f8efb30d",
+            "type": "color"
+          },
+          "200": {
+            "value": "#f5e78e0d",
+            "type": "color"
+          },
+          "300": {
+            "value": "#f0dc5b0d",
+            "type": "color"
+          },
+          "400": {
+            "value": "#edd53b0d",
+            "type": "color"
+          },
+          "500": {
+            "value": "#e9cb0a0d",
+            "type": "color"
+          },
+          "600": {
+            "value": "#d4b9090d",
+            "type": "color"
+          },
+          "700": {
+            "value": "#7f6f050d",
+            "type": "color"
+          },
+          "800": {
+            "value": "#5247030d",
+            "type": "color"
+          },
+          "900": {
+            "value": "#332c020d",
+            "type": "color"
+          }
+        },
+        "00": {
+          "value": "#ffffff",
+          "type": "color"
+        }
+      }
+    },
+    "0%": {
+      "transparent": {
+        "value": "#ffffff00",
+        "type": "color"
+      }
+    },
+    "60%": {
+      "grey": {
+        "50": {
+          "value": "#ffffff99",
+          "type": "color"
+        },
+        "100": {
+          "value": "#f0edee99",
+          "type": "color"
+        },
+        "200": {
+          "value": "#dad8d999",
+          "type": "color"
+        },
+        "300": {
+          "value": "#b9b9b999",
+          "type": "color"
+        },
+        "400": {
+          "value": "#97979799",
+          "type": "color"
+        },
+        "500": {
+          "value": "#67676799",
+          "type": "color"
+        },
+        "600": {
+          "value": "#49494999",
+          "type": "color"
+        },
+        "700": {
+          "value": "#30303099",
+          "type": "color"
+        },
+        "800": {
+          "value": "#1c1c1c99",
+          "type": "color"
+        },
+        "900": {
+          "value": "#00000099",
+          "type": "color"
+        }
+      },
+      "brand": {
+        "jupiter": {
+          "50": {
+            "value": "#fff2e799",
+            "type": "color"
+          },
+          "100": {
+            "value": "#ffd7b499",
+            "type": "color"
+          },
+          "200": {
+            "value": "#ffc49099",
+            "type": "color"
+          },
+          "300": {
+            "value": "#ffa95e99",
+            "type": "color"
+          },
+          "400": {
+            "value": "#ff993e99",
+            "type": "color"
+          },
+          "500": {
+            "value": "#ff7f0e99",
+            "type": "color"
+          },
+          "600": {
+            "value": "#e8740d99",
+            "type": "color"
+          },
+          "700": {
+            "value": "#b55a0a99",
+            "type": "color"
+          },
+          "800": {
+            "value": "#8c460899",
+            "type": "color"
+          },
+          "900": {
+            "value": "#6b350699",
+            "type": "color"
+          }
+        },
+        "saturn": {
+          "50": {
+            "value": "#fff7e699",
+            "type": "color"
+          },
+          "100": {
+            "value": "#ffe5b099",
+            "type": "color"
+          },
+          "200": {
+            "value": "#ffd88a99",
+            "type": "color"
+          },
+          "300": {
+            "value": "#ffc75499",
+            "type": "color"
+          },
+          "400": {
+            "value": "#ffbc3399",
+            "type": "color"
+          },
+          "500": {
+            "value": "#ffab0099",
+            "type": "color"
+          },
+          "600": {
+            "value": "#e89c0099",
+            "type": "color"
+          },
+          "700": {
+            "value": "#b5790099",
+            "type": "color"
+          },
+          "800": {
+            "value": "#8c5e0099",
+            "type": "color"
+          },
+          "900": {
+            "value": "#6b480099",
+            "type": "color"
+          }
+        },
+        "uranus": {
+          "50": {
+            "value": "#f2f9fb99",
+            "type": "color"
+          },
+          "100": {
+            "value": "#d8ecf399",
+            "type": "color"
+          },
+          "200": {
+            "value": "#c5e3ed99",
+            "type": "color"
+          },
+          "300": {
+            "value": "#abd7e499",
+            "type": "color"
+          },
+          "400": {
+            "value": "#9acfdf99",
+            "type": "color"
+          },
+          "500": {
+            "value": "#81c3d799",
+            "type": "color"
+          },
+          "600": {
+            "value": "#75b1c499",
+            "type": "color"
+          },
+          "700": {
+            "value": "#5c8a9999",
+            "type": "color"
+          },
+          "800": {
+            "value": "#476b7699",
+            "type": "color"
+          },
+          "900": {
+            "value": "#36525a99",
+            "type": "color"
+          }
+        },
+        "neptune": {
+          "50": {
+            "value": "#ebf2f699",
+            "type": "color"
+          },
+          "100": {
+            "value": "#c2d6e399",
+            "type": "color"
+          },
+          "200": {
+            "value": "#a4c3d699",
+            "type": "color"
+          },
+          "300": {
+            "value": "#7ba7c399",
+            "type": "color"
+          },
+          "400": {
+            "value": "#6196b799",
+            "type": "color"
+          },
+          "500": {
+            "value": "#3a7ca599",
+            "type": "color"
+          },
+          "600": {
+            "value": "#35719699",
+            "type": "color"
+          },
+          "700": {
+            "value": "#29587599",
+            "type": "color"
+          },
+          "800": {
+            "value": "#20445b99",
+            "type": "color"
+          },
+          "900": {
+            "value": "#18344599",
+            "type": "color"
+          }
+        },
+        "nebula": {
+          "50": {
+            "value": "#f1ebf799",
+            "type": "color"
+          },
+          "100": {
+            "value": "#d4c2e599",
+            "type": "color"
+          },
+          "200": {
+            "value": "#bfa4d999",
+            "type": "color"
+          },
+          "300": {
+            "value": "#a17ac799",
+            "type": "color"
+          },
+          "400": {
+            "value": "#8f61bd99",
+            "type": "color"
+          },
+          "500": {
+            "value": "#7339ac99",
+            "type": "color"
+          },
+          "600": {
+            "value": "#69349d99",
+            "type": "color"
+          },
+          "700": {
+            "value": "#52287a99",
+            "type": "color"
+          },
+          "800": {
+            "value": "#3f1f5f99",
+            "type": "color"
+          },
+          "900": {
+            "value": "#30184899",
+            "type": "color"
+          }
+        },
+        "cosmic": {
+          "50": {
+            "value": "#ebedf799",
+            "type": "color"
+          },
+          "100": {
+            "value": "#c2c8e599",
+            "type": "color"
+          },
+          "200": {
+            "value": "#a4add999",
+            "type": "color"
+          },
+          "300": {
+            "value": "#7a87c799",
+            "type": "color"
+          },
+          "400": {
+            "value": "#6170bd99",
+            "type": "color"
+          },
+          "500": {
+            "value": "#394cac99",
+            "type": "color"
+          },
+          "600": {
+            "value": "#34459d99",
+            "type": "color"
+          },
+          "700": {
+            "value": "#28367a99",
+            "type": "color"
+          },
+          "800": {
+            "value": "#1f2a5f99",
+            "type": "color"
+          },
+          "900": {
+            "value": "#18204899",
+            "type": "color"
+          }
+        },
+        "00": {
+          "value": "#ffffff",
+          "type": "color"
+        }
+      },
+      "alert": {
+        "success": {
+          "50": {
+            "value": "#ecf9ed99",
+            "type": "color"
+          },
+          "100": {
+            "value": "#c4ebc699",
+            "type": "color"
+          },
+          "200": {
+            "value": "#a7e2aa99",
+            "type": "color"
+          },
+          "300": {
+            "value": "#7fd48399",
+            "type": "color"
+          },
+          "400": {
+            "value": "#66cc6b99",
+            "type": "color"
+          },
+          "500": {
+            "value": "#3aae4099",
+            "type": "color"
+          },
+          "600": {
+            "value": "#2d883299",
+            "type": "color"
+          },
+          "700": {
+            "value": "#23692799",
+            "type": "color"
+          },
+          "800": {
+            "value": "#1b501d99",
+            "type": "color"
+          },
+          "900": {
+            "value": "#153d1699",
+            "type": "color"
+          }
+        },
+        "info": {
+          "50": {
+            "value": "#eaf8f699",
+            "type": "color"
+          },
+          "100": {
+            "value": "#bee8e499",
+            "type": "color"
+          },
+          "200": {
+            "value": "#9fddd799",
+            "type": "color"
+          },
+          "300": {
+            "value": "#73cec599",
+            "type": "color"
+          },
+          "400": {
+            "value": "#58c5ba99",
+            "type": "color"
+          },
+          "500": {
+            "value": "#2eb6a999",
+            "type": "color"
+          },
+          "600": {
+            "value": "#2aa69a99",
+            "type": "color"
+          },
+          "700": {
+            "value": "#21817899",
+            "type": "color"
+          },
+          "800": {
+            "value": "#134c4799",
+            "type": "color"
+          },
+          "900": {
+            "value": "#134c4799",
+            "type": "color"
+          }
+        },
+        "warning": {
+          "50": {
+            "value": "#fdfae799",
+            "type": "color"
+          },
+          "100": {
+            "value": "#f8efb399",
+            "type": "color"
+          },
+          "200": {
+            "value": "#f5e78e99",
+            "type": "color"
+          },
+          "300": {
+            "value": "#f0dc5b99",
+            "type": "color"
+          },
+          "400": {
+            "value": "#edd53b99",
+            "type": "color"
+          },
+          "500": {
+            "value": "#e9cb0a99",
+            "type": "color"
+          },
+          "600": {
+            "value": "#d4b90999",
+            "type": "color"
+          },
+          "700": {
+            "value": "#7f6f0599",
+            "type": "color"
+          },
+          "800": {
+            "value": "#52470399",
+            "type": "color"
+          },
+          "900": {
+            "value": "#332c0299",
+            "type": "color"
+          }
+        },
+        "error": {
+          "50": {
+            "value": "#f9ecec99",
+            "type": "color"
+          },
+          "100": {
+            "value": "#ebc4c499",
+            "type": "color"
+          },
+          "200": {
+            "value": "#e2a7a799",
+            "type": "color"
+          },
+          "300": {
+            "value": "#d47f7f99",
+            "type": "color"
+          },
+          "400": {
+            "value": "#cc666699",
+            "type": "color"
+          },
+          "500": {
+            "value": "#bf404099",
+            "type": "color"
+          },
+          "600": {
+            "value": "#ae3a3a99",
+            "type": "color"
+          },
+          "700": {
+            "value": "#882d2d99",
+            "type": "color"
+          },
+          "800": {
+            "value": "#69232399",
+            "type": "color"
+          },
+          "900": {
+            "value": "#501b1b99",
+            "type": "color"
+          }
+        },
+        "00": {
+          "value": "#ffffff",
+          "type": "color"
+        }
+      }
+    },
+    "25%": {
+      "grey": {
+        "50": {
+          "value": "#ffffff40",
+          "type": "color"
+        },
+        "100": {
+          "value": "#f0edee40",
+          "type": "color"
+        },
+        "200": {
+          "value": "#dad8d940",
+          "type": "color"
+        },
+        "300": {
+          "value": "#b9b9b940",
+          "type": "color"
+        },
+        "400": {
+          "value": "#97979740",
+          "type": "color"
+        },
+        "500": {
+          "value": "#67676740",
+          "type": "color"
+        },
+        "600": {
+          "value": "#49494940",
+          "type": "color"
+        },
+        "700": {
+          "value": "#30303040",
+          "type": "color"
+        },
+        "800": {
+          "value": "#1c1c1c40",
+          "type": "color"
+        },
+        "900": {
+          "value": "#00000040",
+          "type": "color"
+        }
+      },
+      "brand": {
+        "jupiter": {
+          "50": {
+            "value": "#fff2e740",
+            "type": "color"
+          },
+          "100": {
+            "value": "#ffd7b440",
+            "type": "color"
+          },
+          "200": {
+            "value": "#ffc49040",
+            "type": "color"
+          },
+          "300": {
+            "value": "#ffa95e40",
+            "type": "color"
+          },
+          "400": {
+            "value": "#ff993e40",
+            "type": "color"
+          },
+          "500": {
+            "value": "#ff7f0e40",
+            "type": "color"
+          },
+          "600": {
+            "value": "#e8740d40",
+            "type": "color"
+          },
+          "700": {
+            "value": "#b55a0a40",
+            "type": "color"
+          },
+          "800": {
+            "value": "#8c460840",
+            "type": "color"
+          },
+          "900": {
+            "value": "#6b350640",
+            "type": "color"
+          }
+        },
+        "saturn": {
+          "50": {
+            "value": "#fff7e640",
+            "type": "color"
+          },
+          "100": {
+            "value": "#ffe5b040",
+            "type": "color"
+          },
+          "200": {
+            "value": "#ffd88a40",
+            "type": "color"
+          },
+          "300": {
+            "value": "#ffc75440",
+            "type": "color"
+          },
+          "400": {
+            "value": "#ffbc3340",
+            "type": "color"
+          },
+          "500": {
+            "value": "#ffab0040",
+            "type": "color"
+          },
+          "600": {
+            "value": "#e89c0040",
+            "type": "color"
+          },
+          "700": {
+            "value": "#b5790040",
+            "type": "color"
+          },
+          "800": {
+            "value": "#8c5e0040",
+            "type": "color"
+          },
+          "900": {
+            "value": "#6b480040",
+            "type": "color"
+          }
+        },
+        "uranus": {
+          "50": {
+            "value": "#f2f9fb40",
+            "type": "color"
+          },
+          "100": {
+            "value": "#d8ecf340",
+            "type": "color"
+          },
+          "200": {
+            "value": "#c5e3ed40",
+            "type": "color"
+          },
+          "300": {
+            "value": "#abd7e440",
+            "type": "color"
+          },
+          "400": {
+            "value": "#9acfdf40",
+            "type": "color"
+          },
+          "500": {
+            "value": "#81c3d740",
+            "type": "color"
+          },
+          "600": {
+            "value": "#75b1c440",
+            "type": "color"
+          },
+          "700": {
+            "value": "#5c8a9940",
+            "type": "color"
+          },
+          "800": {
+            "value": "#476b7640",
+            "type": "color"
+          },
+          "900": {
+            "value": "#36525a40",
+            "type": "color"
+          }
+        },
+        "neptune": {
+          "50": {
+            "value": "#ebf2f640",
+            "type": "color"
+          },
+          "100": {
+            "value": "#c2d6e340",
+            "type": "color"
+          },
+          "200": {
+            "value": "#a4c3d640",
+            "type": "color"
+          },
+          "300": {
+            "value": "#7ba7c340",
+            "type": "color"
+          },
+          "400": {
+            "value": "#6196b740",
+            "type": "color"
+          },
+          "500": {
+            "value": "#3a7ca540",
+            "type": "color"
+          },
+          "600": {
+            "value": "#35719640",
+            "type": "color"
+          },
+          "700": {
+            "value": "#29587540",
+            "type": "color"
+          },
+          "800": {
+            "value": "#20445b40",
+            "type": "color"
+          },
+          "900": {
+            "value": "#18344540",
+            "type": "color"
+          }
+        },
+        "nebula": {
+          "50": {
+            "value": "#f1ebf740",
+            "type": "color"
+          },
+          "100": {
+            "value": "#d4c2e540",
+            "type": "color"
+          },
+          "200": {
+            "value": "#bfa4d940",
+            "type": "color"
+          },
+          "300": {
+            "value": "#a17ac740",
+            "type": "color"
+          },
+          "400": {
+            "value": "#8f61bd40",
+            "type": "color"
+          },
+          "500": {
+            "value": "#7339ac40",
+            "type": "color"
+          },
+          "600": {
+            "value": "#69349d40",
+            "type": "color"
+          },
+          "700": {
+            "value": "#52287a40",
+            "type": "color"
+          },
+          "800": {
+            "value": "#3f1f5f40",
+            "type": "color"
+          },
+          "900": {
+            "value": "#30184840",
+            "type": "color"
+          }
+        },
+        "cosmic": {
+          "50": {
+            "value": "#ebedf740",
+            "type": "color"
+          },
+          "100": {
+            "value": "#c2c8e540",
+            "type": "color"
+          },
+          "200": {
+            "value": "#a4add940",
+            "type": "color"
+          },
+          "300": {
+            "value": "#7a87c740",
+            "type": "color"
+          },
+          "400": {
+            "value": "#6170bd40",
+            "type": "color"
+          },
+          "500": {
+            "value": "#394cac40",
+            "type": "color"
+          },
+          "600": {
+            "value": "#34459d40",
+            "type": "color"
+          },
+          "700": {
+            "value": "#28367a40",
+            "type": "color"
+          },
+          "800": {
+            "value": "#1f2a5f40",
+            "type": "color"
+          },
+          "900": {
+            "value": "#18204840",
+            "type": "color"
+          }
+        },
+        "00": {
+          "value": "#ffffff",
+          "type": "color"
+        }
+      },
+      "alert": {
+        "success": {
+          "50": {
+            "value": "#ecf9ed40",
+            "type": "color"
+          },
+          "100": {
+            "value": "#c4ebc640",
+            "type": "color"
+          },
+          "200": {
+            "value": "#a7e2aa40",
+            "type": "color"
+          },
+          "300": {
+            "value": "#7fd48340",
+            "type": "color"
+          },
+          "400": {
+            "value": "#66cc6b40",
+            "type": "color"
+          },
+          "500": {
+            "value": "#3aae4040",
+            "type": "color"
+          },
+          "600": {
+            "value": "#2d883240",
+            "type": "color"
+          },
+          "700": {
+            "value": "#23692740",
+            "type": "color"
+          },
+          "800": {
+            "value": "#1b501d40",
+            "type": "color"
+          },
+          "900": {
+            "value": "#153d1640",
+            "type": "color"
+          }
+        },
+        "info": {
+          "50": {
+            "value": "#eaf8f640",
+            "type": "color"
+          },
+          "100": {
+            "value": "#bee8e440",
+            "type": "color"
+          },
+          "300": {
+            "value": "#73cec540",
+            "type": "color"
+          },
+          "400": {
+            "value": "#58c5ba40",
+            "type": "color"
+          },
+          "500": {
+            "value": "#2eb6a940",
+            "type": "color"
+          },
+          "600": {
+            "value": "#2aa69a40",
+            "type": "color"
+          },
+          "700": {
+            "value": "#21817840",
+            "type": "color"
+          },
+          "800": {
+            "value": "#11454140",
+            "type": "color"
+          },
+          "900": {
+            "value": "#134c4740",
+            "type": "color"
+          }
+        },
+        "warning": {
+          "50": {
+            "value": "#fdfae740",
+            "type": "color"
+          },
+          "100": {
+            "value": "#f8efb340",
+            "type": "color"
+          },
+          "200": {
+            "value": "#f5e78e40",
+            "type": "color"
+          },
+          "300": {
+            "value": "#f0dc5b40",
+            "type": "color"
+          },
+          "400": {
+            "value": "#edd53b40",
+            "type": "color"
+          },
+          "500": {
+            "value": "#e9cb0a40",
+            "type": "color"
+          },
+          "600": {
+            "value": "#d4b90940",
+            "type": "color"
+          },
+          "700": {
+            "value": "#73640540",
+            "type": "color"
+          },
+          "800": {
+            "value": "#52470340",
+            "type": "color"
+          },
+          "900": {
+            "value": "#332c0240",
+            "type": "color"
+          }
+        },
+        "error": {
+          "50": {
+            "value": "#f9ecec40",
+            "type": "color"
+          },
+          "100": {
+            "value": "#ebc4c440",
+            "type": "color"
+          },
+          "300": {
+            "value": "#d47f7f40",
+            "type": "color"
+          },
+          "400": {
+            "value": "#cc666640",
+            "type": "color"
+          },
+          "500": {
+            "value": "#bf404040",
+            "type": "color"
+          },
+          "600": {
+            "value": "#ae3a3a40",
+            "type": "color"
+          },
+          "700": {
+            "value": "#882d2d40",
+            "type": "color"
+          },
+          "800": {
+            "value": "#69232340",
+            "type": "color"
+          },
+          "900": {
+            "value": "#501b1b40",
+            "type": "color"
+          }
+        },
+        "00": {
+          "value": "#ffffff",
+          "type": "color"
+        }
+      }
+    },
+    "40%": {
+      "grey": {
+        "50": {
+          "value": "#ffffff66",
+          "type": "color"
+        },
+        "100": {
+          "value": "#f0edee66",
+          "type": "color"
+        },
+        "200": {
+          "value": "#dad8d966",
+          "type": "color"
+        },
+        "300": {
+          "value": "#b9b9b966",
+          "type": "color"
+        },
+        "400": {
+          "value": "#97979766",
+          "type": "color"
+        },
+        "500": {
+          "value": "#67676766",
+          "type": "color"
+        },
+        "600": {
+          "value": "#49494966",
+          "type": "color"
+        },
+        "700": {
+          "value": "#30303066",
+          "type": "color"
+        },
+        "800": {
+          "value": "#1c1c1c66",
+          "type": "color"
+        },
+        "900": {
+          "value": "#00000066",
+          "type": "color"
+        }
+      },
+      "brand": {
+        "jupiter": {
+          "50": {
+            "value": "#fff2e766",
+            "type": "color"
+          },
+          "100": {
+            "value": "#ffd7b466",
+            "type": "color"
+          },
+          "200": {
+            "value": "#ffc49066",
+            "type": "color"
+          },
+          "300": {
+            "value": "#ffa95e66",
+            "type": "color"
+          },
+          "400": {
+            "value": "#ff993e66",
+            "type": "color"
+          },
+          "500": {
+            "value": "#ff7f0e66",
+            "type": "color"
+          },
+          "600": {
+            "value": "#e8740d66",
+            "type": "color"
+          },
+          "700": {
+            "value": "#b55a0a66",
+            "type": "color"
+          },
+          "800": {
+            "value": "#8c460866",
+            "type": "color"
+          },
+          "900": {
+            "value": "#6b350666",
+            "type": "color"
+          }
+        },
+        "saturn": {
+          "50": {
+            "value": "#fff7e666",
+            "type": "color"
+          },
+          "100": {
+            "value": "#ffe5b066",
+            "type": "color"
+          },
+          "200": {
+            "value": "#ffd88a66",
+            "type": "color"
+          },
+          "300": {
+            "value": "#ffc75466",
+            "type": "color"
+          },
+          "400": {
+            "value": "#ffbc3366",
+            "type": "color"
+          },
+          "500": {
+            "value": "#ffab0066",
+            "type": "color"
+          },
+          "600": {
+            "value": "#e89c0066",
+            "type": "color"
+          },
+          "700": {
+            "value": "#b5790066",
+            "type": "color"
+          },
+          "800": {
+            "value": "#8c5e0066",
+            "type": "color"
+          },
+          "900": {
+            "value": "#6b480066",
+            "type": "color"
+          }
+        },
+        "uranus": {
+          "50": {
+            "value": "#f2f9fb66",
+            "type": "color"
+          },
+          "100": {
+            "value": "#d8ecf366",
+            "type": "color"
+          },
+          "200": {
+            "value": "#c5e3ed66",
+            "type": "color"
+          },
+          "300": {
+            "value": "#abd7e466",
+            "type": "color"
+          },
+          "400": {
+            "value": "#9acfdf66",
+            "type": "color"
+          },
+          "500": {
+            "value": "#81c3d766",
+            "type": "color"
+          },
+          "600": {
+            "value": "#75b1c466",
+            "type": "color"
+          },
+          "700": {
+            "value": "#5c8a9966",
+            "type": "color"
+          },
+          "800": {
+            "value": "#476b7666",
+            "type": "color"
+          },
+          "900": {
+            "value": "#36525a66",
+            "type": "color"
+          }
+        },
+        "neptune": {
+          "50": {
+            "value": "#ebf2f666",
+            "type": "color"
+          },
+          "100": {
+            "value": "#c2d6e366",
+            "type": "color"
+          },
+          "200": {
+            "value": "#a4c3d666",
+            "type": "color"
+          },
+          "300": {
+            "value": "#7ba7c366",
+            "type": "color"
+          },
+          "400": {
+            "value": "#6196b766",
+            "type": "color"
+          },
+          "500": {
+            "value": "#3a7ca566",
+            "type": "color"
+          },
+          "600": {
+            "value": "#35719666",
+            "type": "color"
+          },
+          "700": {
+            "value": "#29587566",
+            "type": "color"
+          },
+          "800": {
+            "value": "#20445b66",
+            "type": "color"
+          },
+          "900": {
+            "value": "#18344566",
+            "type": "color"
+          }
+        },
+        "nebula": {
+          "50": {
+            "value": "#f1ebf766",
+            "type": "color"
+          },
+          "100": {
+            "value": "#d4c2e566",
+            "type": "color"
+          },
+          "200": {
+            "value": "#bfa4d966",
+            "type": "color"
+          },
+          "300": {
+            "value": "#a17ac766",
+            "type": "color"
+          },
+          "400": {
+            "value": "#8f61bd66",
+            "type": "color"
+          },
+          "500": {
+            "value": "#7339ac66",
+            "type": "color"
+          },
+          "600": {
+            "value": "#69349d66",
+            "type": "color"
+          },
+          "700": {
+            "value": "#52287a66",
+            "type": "color"
+          },
+          "800": {
+            "value": "#3f1f5f66",
+            "type": "color"
+          },
+          "900": {
+            "value": "#30184866",
+            "type": "color"
+          }
+        },
+        "cosmic": {
+          "50": {
+            "value": "#ebedf766",
+            "type": "color"
+          },
+          "100": {
+            "value": "#c2c8e566",
+            "type": "color"
+          },
+          "200": {
+            "value": "#a4add966",
+            "type": "color"
+          },
+          "300": {
+            "value": "#7a87c766",
+            "type": "color"
+          },
+          "400": {
+            "value": "#6170bd66",
+            "type": "color"
+          },
+          "500": {
+            "value": "#394cac66",
+            "type": "color"
+          },
+          "600": {
+            "value": "#34459d66",
+            "type": "color"
+          },
+          "700": {
+            "value": "#28367a66",
+            "type": "color"
+          },
+          "800": {
+            "value": "#1f2a5f66",
+            "type": "color"
+          },
+          "900": {
+            "value": "#18204866",
+            "type": "color"
+          }
+        },
+        "00": {
+          "value": "#ffffff",
+          "type": "color"
+        }
+      },
+      "alert": {
+        "success": {
+          "50": {
+            "value": "#ecf9ed66",
+            "type": "color"
+          },
+          "100": {
+            "value": "#c4ebc666",
+            "type": "color"
+          },
+          "200": {
+            "value": "#a7e2aa66",
+            "type": "color"
+          },
+          "300": {
+            "value": "#7fd48366",
+            "type": "color"
+          },
+          "400": {
+            "value": "#66cc6b66",
+            "type": "color"
+          },
+          "500": {
+            "value": "#3aae4066",
+            "type": "color"
+          },
+          "600": {
+            "value": "#2d883266",
+            "type": "color"
+          },
+          "700": {
+            "value": "#23692766",
+            "type": "color"
+          },
+          "800": {
+            "value": "#1b501d66",
+            "type": "color"
+          },
+          "900": {
+            "value": "#153d1666",
+            "type": "color"
+          }
+        },
+        "info": {
+          "50": {
+            "value": "#eaf8f666",
+            "type": "color"
+          },
+          "100": {
+            "value": "#bee8e466",
+            "type": "color"
+          },
+          "300": {
+            "value": "#73cec566",
+            "type": "color"
+          },
+          "400": {
+            "value": "#58c5ba66",
+            "type": "color"
+          },
+          "500": {
+            "value": "#2eb6a966",
+            "type": "color"
+          },
+          "600": {
+            "value": "#2aa69a66",
+            "type": "color"
+          },
+          "700": {
+            "value": "#21817866",
+            "type": "color"
+          },
+          "800": {
+            "value": "#11454166",
+            "type": "color"
+          },
+          "900": {
+            "value": "#134c4766",
+            "type": "color"
+          }
+        },
+        "warning": {
+          "50": {
+            "value": "#fdfae766",
+            "type": "color"
+          },
+          "100": {
+            "value": "#f8efb366",
+            "type": "color"
+          },
+          "200": {
+            "value": "#f5e78e66",
+            "type": "color"
+          },
+          "300": {
+            "value": "#f0dc5b66",
+            "type": "color"
+          },
+          "400": {
+            "value": "#edd53b66",
+            "type": "color"
+          },
+          "500": {
+            "value": "#e9cb0a66",
+            "type": "color"
+          },
+          "600": {
+            "value": "#d4b90966",
+            "type": "color"
+          },
+          "700": {
+            "value": "#7f6f0566",
+            "type": "color"
+          },
+          "800": {
+            "value": "#52470366",
+            "type": "color"
+          },
+          "900": {
+            "value": "#332c0266",
+            "type": "color"
+          }
+        },
+        "error": {
+          "50": {
+            "value": "#f9ecec66",
+            "type": "color"
+          },
+          "100": {
+            "value": "#ebc4c466",
+            "type": "color"
+          },
+          "300": {
+            "value": "#d47f7f66",
+            "type": "color"
+          },
+          "400": {
+            "value": "#cc666666",
+            "type": "color"
+          },
+          "500": {
+            "value": "#bf404066",
+            "type": "color"
+          },
+          "600": {
+            "value": "#ae3a3a66",
+            "type": "color"
+          },
+          "700": {
+            "value": "#882d2d66",
+            "type": "color"
+          },
+          "800": {
+            "value": "#69232366",
+            "type": "color"
+          },
+          "900": {
+            "value": "#501b1b66",
+            "type": "color"
+          }
+        },
+        "00": {
+          "value": "#ffffff",
+          "type": "color"
+        }
+      }
+    }
+  },
+  "scale-ui/base": {
+    "is-base": {
+      "value": "false",
+      "type": "boolean"
+    },
+    "is-sm": {
+      "value": "false",
+      "type": "boolean"
+    },
+    "is-lg": {
+      "value": "true",
+      "type": "boolean"
+    },
+    "button": {
+      "default": {
+        "text": {
+          "font-weight": {
+            "value": "{font.weight.normal}",
+            "type": "text"
+          },
+          "line-height": {
+            "value": "{font.line-height.ui.base.button}",
+            "type": "dimension"
+          },
+          "font-size": {
+            "value": "{font.size.ui.base.button}",
+            "type": "dimension"
+          }
+        },
+        "space": {
+          "g-x": {
+            "value": "{global.4px|025rem}",
+            "type": "dimension"
+          },
+          "g-y": {
+            "value": "{global.4px|025rem}",
+            "type": "dimension"
+          },
+          "p-x": {
+            "value": "{padding.p-static.xxl}",
+            "type": "dimension"
+          },
+          "p-y": {
+            "value": "{padding.p-static.lg}",
+            "type": "dimension"
+          }
+        },
+        "border": {
+          "radius": {
+            "value": "{rounded.md}",
+            "type": "dimension"
+          },
+          "width": {
+            "value": "{global.2px|0125rem}",
+            "type": "dimension"
+          }
+        },
+        "icon": {
+          "icon-size": {
+            "value": "{global.20px|1-25rem}",
+            "type": "dimension"
+          }
+        },
+        "indicator": {
+          "padding": {
+            "p-y": {
+              "value": "{global.0}",
+              "type": "dimension"
+            },
+            "start-x": {
+              "value": "{global.0}",
+              "type": "dimension"
+            },
+            "end-x": {
+              "value": "{global.0}",
+              "type": "dimension"
+            }
+          },
+          "border": {
+            "width": {
+              "value": "{global.0}",
+              "type": "dimension"
+            },
+            "radius": {
+              "value": "{rounded.md}",
+              "type": "dimension"
+            }
+          }
+        }
+      },
+      "hover": {
+        "text": {
+          "font-weight": {
+            "value": "{font.weight.semibold}",
+            "type": "text"
+          },
+          "font-size": {
+            "value": "{font.size.ui.base.button}",
+            "type": "dimension"
+          },
+          "line-height": {
+            "value": "{font.line-height.ui.base.button}",
+            "type": "dimension"
+          }
+        },
+        "border": {
+          "radius": {
+            "value": "{rounded.md}",
+            "type": "dimension"
+          },
+          "width": {
+            "value": "{global.4px|025rem}",
+            "type": "dimension"
+          }
+        },
+        "space": {
+          "p-x": {
+            "value": "{global.16px|1rem}",
+            "type": "dimension"
+          },
+          "p-y": {
+            "value": "{global.12px|075rem}",
+            "type": "dimension"
+          },
+          "g-x": {
+            "value": "{global.4px|025rem}",
+            "type": "dimension"
+          },
+          "g-y": {
+            "value": "{global.4px|025rem}",
+            "type": "dimension"
+          }
+        },
+        "icon": {
+          "icon-size": {
+            "value": "{global.20px|1-25rem}",
+            "type": "dimension"
+          }
+        },
+        "indicator": {
+          "border": {
+            "radius": {
+              "value": "{rounded.md}",
+              "type": "dimension"
+            },
+            "width": {
+              "value": "{global.0}",
+              "type": "dimension"
+            }
+          },
+          "padding": {
+            "p-y": {
+              "value": "{global.0}",
+              "type": "dimension"
+            },
+            "start-x": {
+              "value": "0.0625rem",
+              "type": "dimension"
+            },
+            "end-x": {
+              "value": "0.0625rem",
+              "type": "dimension"
+            }
+          }
+        }
+      },
+      "focus": {
+        "text": {
+          "font-weight": {
+            "value": "{font.weight.medium}",
+            "type": "text"
+          },
+          "font-size": {
+            "value": "{font.size.ui.base.button}",
+            "type": "dimension"
+          },
+          "line-height": {
+            "value": "{font.line-height.ui.base.button}",
+            "type": "dimension"
+          }
+        },
+        "border": {
+          "radius": {
+            "value": "{rounded.md}",
+            "type": "dimension"
+          },
+          "width": {
+            "value": "{global.2px|0125rem}",
+            "type": "dimension"
+          }
+        },
+        "space": {
+          "p-x": {
+            "value": "{global.14px|0875rem}",
+            "type": "dimension"
+          },
+          "p-y": {
+            "value": "{global.8px|05rem}",
+            "type": "dimension"
+          },
+          "g-x": {
+            "value": "{global.4px|025rem}",
+            "type": "dimension"
+          },
+          "g-y": {
+            "value": "{global.4px|025rem}",
+            "type": "dimension"
+          }
+        },
+        "icon": {
+          "icon-size": {
+            "value": "{global.20px|1-25rem}",
+            "type": "dimension"
+          }
+        },
+        "indicator": {
+          "border": {
+            "radius": {
+              "value": "{rounded.md}",
+              "type": "dimension"
+            },
+            "width": {
+              "value": "{global.2px|0125rem}",
+              "type": "dimension"
+            }
+          },
+          "padding": {
+            "p-y": {
+              "value": "{global.4px|025rem}",
+              "type": "dimension"
+            },
+            "start-x": {
+              "value": "0.21875rem",
+              "type": "dimension"
+            },
+            "end-x": {
+              "value": "0.21875rem",
+              "type": "dimension"
+            }
+          }
+        }
+      },
+      "active": {
+        "text": {
+          "font-weight": {
+            "value": "{font.weight.semibold}",
+            "type": "text"
+          },
+          "font-size": {
+            "value": "{font.size.ui.base.button}",
+            "type": "dimension"
+          },
+          "line-height": {
+            "value": "{font.line-height.ui.base.button}",
+            "type": "dimension"
+          }
+        },
+        "border": {
+          "radius": {
+            "value": "{rounded.md}",
+            "type": "dimension"
+          },
+          "width": {
+            "value": "{global.2px|0125rem}",
+            "type": "dimension"
+          }
+        },
+        "space": {
+          "p-x": {
+            "value": "{global.12px|075rem}",
+            "type": "dimension"
+          },
+          "p-y": {
+            "value": "{global.8px|05rem}",
+            "type": "dimension"
+          },
+          "g-x": {
+            "value": "{global.4px|025rem}",
+            "type": "dimension"
+          },
+          "g-y": {
+            "value": "{global.4px|025rem}",
+            "type": "dimension"
+          }
+        },
+        "icon": {
+          "icon-size": {
+            "value": "{global.20px|1-25rem}",
+            "type": "dimension"
+          }
+        },
+        "indicator": {
+          "border": {
+            "radius": {
+              "value": "{rounded.md}",
+              "type": "dimension"
+            },
+            "width": {
+              "value": "{global.2px|0125rem}",
+              "type": "dimension"
+            }
+          },
+          "padding": {
+            "top-y": {
+              "value": "0.25rem",
+              "type": "dimension"
+            },
+            "start-x": {
+              "value": "0.3125rem",
+              "type": "dimension"
+            },
+            "end-x": {
+              "value": "0.3125rem",
+              "type": "dimension"
+            },
+            "bottom-y": {
+              "value": "0.25rem",
+              "type": "dimension"
+            }
+          }
+        }
+      },
+      "disabled": {
+        "text": {
+          "font-weight": {
+            "value": "{font.weight.normal}",
+            "type": "text"
+          },
+          "font-size": {
+            "value": "{font.size.ui.base.button}",
+            "type": "dimension"
+          },
+          "line-height": {
+            "value": "{font.line-height.ui.base.button}",
+            "type": "dimension"
+          }
+        },
+        "border": {
+          "radius": {
+            "value": "{rounded.md}",
+            "type": "dimension"
+          },
+          "width": {
+            "value": "{global.2px|0125rem}",
+            "type": "dimension"
+          }
+        },
+        "space": {
+          "p-x": {
+            "value": "{padding.p-static.xxl}",
+            "type": "dimension"
+          },
+          "p-y": {
+            "value": "{padding.p-static.lg}",
+            "type": "dimension"
+          },
+          "g-x": {
+            "value": "{global.4px|025rem}",
+            "type": "dimension"
+          },
+          "g-y": {
+            "value": "{global.4px|025rem}",
+            "type": "dimension"
+          }
+        },
+        "icon": {
+          "icon-size": {
+            "value": "{global.20px|1-25rem}",
+            "type": "dimension"
+          }
+        },
+        "indicator": {
+          "border": {
+            "radius": {
+              "value": "{rounded.md}",
+              "type": "dimension"
+            },
+            "width": {
+              "value": "{global.0}",
+              "type": "dimension"
+            }
+          },
+          "padding": {
+            "p-y": {
+              "value": "{global.0}",
+              "type": "dimension"
+            },
+            "p-x": {
+              "value": "{global.0}",
+              "type": "dimension"
+            }
+          }
+        }
+      }
+    },
+    "link": {
+      "size": {
+        "value": "{font.size.ui.base.link}",
+        "type": "dimension"
+      },
+      "line-height": {
+        "value": "{font.line-height.ui.base.link}",
+        "type": "dimension"
+      },
+      "border-width": {
+        "value": "{border-width.sm}",
+        "type": "dimension"
+      },
+      "letter-spacing-default": {
+        "value": "0rem",
+        "type": "dimension"
+      },
+      "letter-spacing-hover": {
+        "value": "-0.008124999701976776rem",
+        "type": "dimension"
+      },
+      "letter-spacing-focus": {
+        "value": "-0.008124999701976776rem",
+        "type": "dimension"
+      },
+      "letter-spacing-active": {
+        "value": "-0.008750000037252903rem",
+        "type": "dimension"
+      },
+      "letter-spacing-visited": {
+        "value": "-0.008750000037252903rem",
+        "type": "dimension"
+      },
+      "letter-spacing-disabled": {
+        "value": "0.008750000037252903rem",
+        "type": "dimension"
+      },
+      "size-x": {
+        "value": "{font.size.ui.base.link}",
+        "type": "dimension"
+      },
+      "border-radius": {
+        "value": "{border-width.sm}",
+        "type": "dimension"
+      }
+    },
+    "label": {
+      "line-height": {
+        "value": "{font.line-height.ui.base.label}",
+        "type": "dimension"
+      },
+      "font-size": {
+        "value": "{font.size.ui.base.label}",
+        "type": "dimension"
+      }
+    },
+    "placeholder": {
+      "line-height": {
+        "value": "{font.line-height.ui.base.placeholder}",
+        "type": "dimension"
+      },
+      "font-size": {
+        "value": "{font.size.ui.base.placeholder}",
+        "type": "dimension"
+      }
+    },
+    "logo": {
+      "line-height": {
+        "value": "{font.line-height.ui.base.label}",
+        "type": "dimension"
+      },
+      "font-size": {
+        "value": "{font.size.ui.base.label}",
+        "type": "dimension"
+      },
+      "icon-size-pair": {
+        "value": "0rem",
+        "type": "dimension"
+      },
+      "icon-size": {
+        "value": "0rem",
+        "type": "dimension"
+      },
+      "g-x": {
+        "value": "{global.12px|075rem}",
+        "type": "dimension"
+      },
+      "g-y": {
+        "value": "{global.4px|025rem}",
+        "type": "dimension"
+      }
+    },
+    "nav-item": {
+      "line-height": {
+        "value": "{font.line-height.ui.base.label}",
+        "type": "dimension"
+      },
+      "font-size": {
+        "value": "{font.size.ui.base.label}",
+        "type": "dimension"
+      }
+    },
+    "pull-quote": {
+      "line-height": {
+        "value": "{font.line-height.ui.base.placeholder}",
+        "type": "dimension"
+      },
+      "font-size": {
+        "value": "{font.size.ui.base.placeholder}",
+        "type": "dimension"
+      }
+    },
+    "tool-tip": {
+      "line-height": {
+        "value": "{font.line-height.ui.base.placeholder}",
+        "type": "dimension"
+      },
+      "font-size": {
+        "value": "{font.size.ui.base.placeholder}",
+        "type": "dimension"
+      }
+    },
+    "counter": {
+      "line-height": {
+        "value": "{font.line-height.ui.base.counter}",
+        "type": "dimension"
+      },
+      "font-size": {
+        "value": "{font.size.ui.base.counter}",
+        "type": "dimension"
+      }
+    }
+  },
+  "scale-ui/sm": {
+    "is-base": {
+      "value": "false",
+      "type": "boolean"
+    },
+    "is-sm": {
+      "value": "true",
+      "type": "boolean"
+    },
+    "is-lg": {
+      "value": "false",
+      "type": "boolean"
+    },
+    "button": {
+      "default": {
+        "text": {
+          "font-weight": {
+            "value": "{font.weight.normal}",
+            "type": "text"
+          },
+          "line-height": {
+            "value": "{font.line-height.ui.sm.button}",
+            "type": "dimension"
+          },
+          "font-size": {
+            "value": "{font.size.ui.sm.button}",
+            "type": "dimension"
+          }
+        },
+        "space": {
+          "g-x": {
+            "value": "{global.4px|025rem}",
+            "type": "dimension"
+          },
+          "g-y": {
+            "value": "{global.4px|025rem}",
+            "type": "dimension"
+          },
+          "p-x": {
+            "value": "{padding.p-static.xxl}",
+            "type": "dimension"
+          },
+          "p-y": {
+            "value": "{padding.p-static.lg}",
+            "type": "dimension"
+          }
+        },
+        "border": {
+          "radius": {
+            "value": "{rounded.md}",
+            "type": "dimension"
+          },
+          "width": {
+            "value": "{global.2px|0125rem}",
+            "type": "dimension"
+          }
+        },
+        "icon": {
+          "icon-size": {
+            "value": "{global.18px|089rem}",
+            "type": "dimension"
+          }
+        },
+        "indicator": {
+          "padding": {
+            "p-y": {
+              "value": "{global.0}",
+              "type": "dimension"
+            },
+            "start-x": {
+              "value": "{global.0}",
+              "type": "dimension"
+            },
+            "end-x": {
+              "value": "{global.0}",
+              "type": "dimension"
+            }
+          },
+          "border": {
+            "width": {
+              "value": "{global.0}",
+              "type": "dimension"
+            },
+            "radius": {
+              "value": "{rounded.md}",
+              "type": "dimension"
+            }
+          }
+        }
+      },
+      "hover": {
+        "text": {
+          "font-weight": {
+            "value": "{font.weight.medium}",
+            "type": "text"
+          },
+          "font-size": {
+            "value": "{font.size.ui.sm.button}",
+            "type": "dimension"
+          },
+          "line-height": {
+            "value": "{font.line-height.ui.sm.button}",
+            "type": "dimension"
+          }
+        },
+        "border": {
+          "radius": {
+            "value": "{rounded.md}",
+            "type": "dimension"
+          },
+          "width": {
+            "value": "{global.4px|025rem}",
+            "type": "dimension"
+          }
+        },
+        "space": {
+          "p-x": {
+            "value": "{global.18px|089rem}",
+            "type": "dimension"
+          },
+          "p-y": {
+            "value": "{global.12px|075rem}",
+            "type": "dimension"
+          },
+          "g-x": {
+            "value": "{global.4px|025rem}",
+            "type": "dimension"
+          },
+          "g-y": {
+            "value": "{global.4px|025rem}",
+            "type": "dimension"
+          }
+        },
+        "icon": {
+          "icon-size": {
+            "value": "{global.18px|089rem}",
+            "type": "dimension"
+          }
+        },
+        "indicator": {
+          "border": {
+            "radius": {
+              "value": "{rounded.md}",
+              "type": "dimension"
+            },
+            "width": {
+              "value": "{global.0}",
+              "type": "dimension"
+            }
+          },
+          "padding": {
+            "p-y": {
+              "value": "{global.0}",
+              "type": "dimension"
+            },
+            "start-x": {
+              "value": "{global.0}",
+              "type": "dimension"
+            },
+            "end-x": {
+              "value": "{global.2px|0125rem}",
+              "type": "dimension"
+            }
+          }
+        }
+      },
+      "focus": {
+        "text": {
+          "font-weight": {
+            "value": "{font.weight.medium}",
+            "type": "text"
+          },
+          "font-size": {
+            "value": "{font.size.ui.sm.button}",
+            "type": "dimension"
+          },
+          "line-height": {
+            "value": "{font.line-height.ui.sm.button}",
+            "type": "dimension"
+          }
+        },
+        "border": {
+          "radius": {
+            "value": "{rounded.md}",
+            "type": "dimension"
+          },
+          "width": {
+            "value": "{global.2px|0125rem}",
+            "type": "dimension"
+          }
+        },
+        "space": {
+          "p-x": {
+            "value": "{global.14px|0875rem}",
+            "type": "dimension"
+          },
+          "p-y": {
+            "value": "{global.8px|05rem}",
+            "type": "dimension"
+          },
+          "g-x": {
+            "value": "{global.4px|025rem}",
+            "type": "dimension"
+          },
+          "g-y": {
+            "value": "{global.4px|025rem}",
+            "type": "dimension"
+          }
+        },
+        "icon": {
+          "icon-size": {
+            "value": "{global.18px|089rem}",
+            "type": "dimension"
+          }
+        },
+        "indicator": {
+          "border": {
+            "radius": {
+              "value": "{rounded.md}",
+              "type": "dimension"
+            },
+            "width": {
+              "value": "{global.2px|0125rem}",
+              "type": "dimension"
+            }
+          },
+          "padding": {
+            "p-y": {
+              "value": "{global.4px|025rem}",
+              "type": "dimension"
+            },
+            "start-x": {
+              "value": "{global.4px|025rem}",
+              "type": "dimension"
+            },
+            "end-x": {
+              "value": "{global.4px|025rem}",
+              "type": "dimension"
+            }
+          }
+        }
+      },
+      "active": {
+        "text": {
+          "font-weight": {
+            "value": "{font.weight.semibold}",
+            "type": "text"
+          },
+          "font-size": {
+            "value": "{font.size.ui.sm.button}",
+            "type": "dimension"
+          },
+          "line-height": {
+            "value": "{font.line-height.ui.sm.button}",
+            "type": "dimension"
+          }
+        },
+        "border": {
+          "radius": {
+            "value": "{rounded.md}",
+            "type": "dimension"
+          },
+          "width": {
+            "value": "{global.2px|0125rem}",
+            "type": "dimension"
+          }
+        },
+        "space": {
+          "p-x": {
+            "value": "{global.12px|075rem}",
+            "type": "dimension"
+          },
+          "p-y": {
+            "value": "{global.8px|05rem}",
+            "type": "dimension"
+          },
+          "g-x": {
+            "value": "{global.4px|025rem}",
+            "type": "dimension"
+          },
+          "g-y": {
+            "value": "{global.4px|025rem}",
+            "type": "dimension"
+          }
+        },
+        "icon": {
+          "icon-size": {
+            "value": "{global.18px|089rem}",
+            "type": "dimension"
+          }
+        },
+        "indicator": {
+          "border": {
+            "radius": {
+              "value": "{rounded.md}",
+              "type": "dimension"
+            },
+            "width": {
+              "value": "{global.2px|0125rem}",
+              "type": "dimension"
+            }
+          },
+          "padding": {
+            "top-y": {
+              "value": "{global.0}",
+              "type": "dimension"
+            },
+            "start-x": {
+              "value": "{global.0}",
+              "type": "dimension"
+            },
+            "end-x": {
+              "value": "{global.2px|0125rem}",
+              "type": "dimension"
+            },
+            "bottom-y": {
+              "value": "{global.0}",
+              "type": "dimension"
+            }
+          }
+        }
+      },
+      "disabled": {
+        "text": {
+          "font-weight": {
+            "value": "{font.weight.normal}",
+            "type": "text"
+          },
+          "font-size": {
+            "value": "{font.size.ui.sm.button}",
+            "type": "dimension"
+          },
+          "line-height": {
+            "value": "{font.line-height.ui.sm.button}",
+            "type": "dimension"
+          }
+        },
+        "border": {
+          "radius": {
+            "value": "{rounded.md}",
+            "type": "dimension"
+          },
+          "width": {
+            "value": "{global.2px|0125rem}",
+            "type": "dimension"
+          }
+        },
+        "space": {
+          "p-x": {
+            "value": "{padding.p-static.xxl}",
+            "type": "dimension"
+          },
+          "p-y": {
+            "value": "{padding.p-static.lg}",
+            "type": "dimension"
+          },
+          "g-x": {
+            "value": "{global.4px|025rem}",
+            "type": "dimension"
+          },
+          "g-y": {
+            "value": "{global.4px|025rem}",
+            "type": "dimension"
+          }
+        },
+        "icon": {
+          "icon-size": {
+            "value": "{global.18px|089rem}",
+            "type": "dimension"
+          }
+        },
+        "indicator": {
+          "border": {
+            "radius": {
+              "value": "{rounded.md}",
+              "type": "dimension"
+            },
+            "width": {
+              "value": "{global.0}",
+              "type": "dimension"
+            }
+          },
+          "padding": {
+            "p-y": {
+              "value": "{global.0}",
+              "type": "dimension"
+            },
+            "p-x": {
+              "value": "{global.0}",
+              "type": "dimension"
+            }
+          }
+        }
+      }
+    },
+    "link": {
+      "size": {
+        "value": "{font.size.ui.sm.link}",
+        "type": "dimension"
+      },
+      "line-height": {
+        "value": "{font.line-height.ui.sm.link}",
+        "type": "dimension"
+      },
+      "border-width": {
+        "value": "{border-width.sm}",
+        "type": "dimension"
+      },
+      "letter-spacing-default": {
+        "value": "0rem",
+        "type": "dimension"
+      },
+      "letter-spacing-hover": {
+        "value": "-0.007499999832361937rem",
+        "type": "dimension"
+      },
+      "letter-spacing-focus": {
+        "value": "-0.008124999701976776rem",
+        "type": "dimension"
+      },
+      "letter-spacing-active": {
+        "value": "-0.007499999832361937rem",
+        "type": "dimension"
+      },
+      "letter-spacing-visited": {
+        "value": "-0.007499999832361937rem",
+        "type": "dimension"
+      },
+      "letter-spacing-disabled": {
+        "value": "0.007499999832361937rem",
+        "type": "dimension"
+      },
+      "size-x": {
+        "value": "{font.size.ui.sm.link}",
+        "type": "dimension"
+      },
+      "border-radius": {
+        "value": "{border-width.sm}",
+        "type": "dimension"
+      }
+    },
+    "label": {
+      "line-height": {
+        "value": "{font.line-height.ui.sm.label}",
+        "type": "dimension"
+      },
+      "font-size": {
+        "value": "{font.size.ui.sm.label}",
+        "type": "dimension"
+      }
+    },
+    "placeholder": {
+      "line-height": {
+        "value": "{font.line-height.ui.sm.placeholder}",
+        "type": "dimension"
+      },
+      "font-size": {
+        "value": "{font.size.ui.sm.placeholder}",
+        "type": "dimension"
+      }
+    },
+    "logo": {
+      "line-height": {
+        "value": "{font.line-height.ui.sm.label}",
+        "type": "dimension"
+      },
+      "font-size": {
+        "value": "{font.size.ui.sm.label}",
+        "type": "dimension"
+      },
+      "icon-size-pair": {
+        "value": "0rem",
+        "type": "dimension"
+      },
+      "icon-size": {
+        "value": "0rem",
+        "type": "dimension"
+      },
+      "g-x": {
+        "value": "0rem",
+        "type": "dimension"
+      },
+      "g-y": {
+        "value": "0rem",
+        "type": "dimension"
+      }
+    },
+    "nav-item": {
+      "line-height": {
+        "value": "{font.line-height.ui.sm.label}",
+        "type": "dimension"
+      },
+      "font-size": {
+        "value": "{font.size.ui.sm.label}",
+        "type": "dimension"
+      }
+    },
+    "pull-quote": {
+      "line-height": {
+        "value": "{font.line-height.ui.sm.placeholder}",
+        "type": "dimension"
+      },
+      "font-size": {
+        "value": "{font.size.ui.sm.placeholder}",
+        "type": "dimension"
+      }
+    },
+    "tool-tip": {
+      "line-height": {
+        "value": "{font.line-height.ui.sm.placeholder}",
+        "type": "dimension"
+      },
+      "font-size": {
+        "value": "{font.size.ui.sm.placeholder}",
+        "type": "dimension"
+      }
+    },
+    "counter": {
+      "line-height": {
+        "value": "{font.line-height.ui.sm.counter}",
+        "type": "dimension"
+      },
+      "font-size": {
+        "value": "{font.size.ui.sm.counter}",
+        "type": "dimension"
+      }
+    }
+  },
+  "scale-ui/lg": {
+    "is-base": {
+      "value": "false",
+      "type": "boolean"
+    },
+    "is-sm": {
+      "value": "false",
+      "type": "boolean"
+    },
+    "is-lg": {
+      "value": "true",
+      "type": "boolean"
+    },
+    "button": {
+      "default": {
+        "text": {
+          "font-weight": {
+            "value": "{font.weight.normal}",
+            "type": "text"
+          },
+          "line-height": {
+            "value": "{font.line-height.ui.lg.button}",
+            "type": "dimension"
+          },
+          "font-size": {
+            "value": "{font.size.ui.lg.button}",
+            "type": "dimension"
+          }
+        },
+        "space": {
+          "g-x": {
+            "value": "{global.6px|0375rem}",
+            "type": "dimension"
+          },
+          "g-y": {
+            "value": "{global.4px|025rem}",
+            "type": "dimension"
+          },
+          "p-x": {
+            "value": "{padding.p-static.xxxl}",
+            "type": "dimension"
+          },
+          "p-y": {
+            "value": "{padding.p-static.lg}",
+            "type": "dimension"
+          }
+        },
+        "border": {
+          "radius": {
+            "value": "{rounded.md}",
+            "type": "dimension"
+          },
+          "width": {
+            "value": "{global.2px|0125rem}",
+            "type": "dimension"
+          }
+        },
+        "icon": {
+          "icon-size": {
+            "value": "{global.24px|1-5rem}",
+            "type": "dimension"
+          }
+        },
+        "indicator": {
+          "padding": {
+            "p-y": {
+              "value": "{global.0}",
+              "type": "dimension"
+            },
+            "start-x": {
+              "value": "{global.0}",
+              "type": "dimension"
+            },
+            "end-x": {
+              "value": "{global.0}",
+              "type": "dimension"
+            }
+          },
+          "border": {
+            "width": {
+              "value": "{global.0}",
+              "type": "dimension"
+            },
+            "radius": {
+              "value": "{rounded.md}",
+              "type": "dimension"
+            }
+          }
+        }
+      },
+      "hover": {
+        "text": {
+          "font-weight": {
+            "value": "{font.weight.medium}",
+            "type": "text"
+          },
+          "font-size": {
+            "value": "{font.size.ui.lg.button}",
+            "type": "dimension"
+          },
+          "line-height": {
+            "value": "{font.line-height.ui.lg.button}",
+            "type": "dimension"
+          }
+        },
+        "border": {
+          "radius": {
+            "value": "{rounded.md}",
+            "type": "dimension"
+          },
+          "width": {
+            "value": "{global.4px|025rem}",
+            "type": "dimension"
+          }
+        },
+        "space": {
+          "p-x": {
+            "value": "{global.18px|089rem}",
+            "type": "dimension"
+          },
+          "p-y": {
+            "value": "{global.12px|075rem}",
+            "type": "dimension"
+          },
+          "g-x": {
+            "value": "{global.6px|0375rem}",
+            "type": "dimension"
+          },
+          "g-y": {
+            "value": "{global.4px|025rem}",
+            "type": "dimension"
+          }
+        },
+        "icon": {
+          "icon-size": {
+            "value": "{global.24px|1-5rem}",
+            "type": "dimension"
+          }
+        },
+        "indicator": {
+          "border": {
+            "radius": {
+              "value": "{rounded.md}",
+              "type": "dimension"
+            },
+            "width": {
+              "value": "{global.0}",
+              "type": "dimension"
+            }
+          },
+          "padding": {
+            "p-y": {
+              "value": "{global.0}",
+              "type": "dimension"
+            },
+            "start-x": {
+              "value": "{global.0}",
+              "type": "dimension"
+            },
+            "end-x": {
+              "value": "{global.2px|0125rem}",
+              "type": "dimension"
+            }
+          }
+        }
+      },
+      "focus": {
+        "text": {
+          "font-weight": {
+            "value": "{font.weight.medium}",
+            "type": "text"
+          },
+          "font-size": {
+            "value": "{font.size.ui.lg.button}",
+            "type": "dimension"
+          },
+          "line-height": {
+            "value": "{font.line-height.ui.lg.button}",
+            "type": "dimension"
+          }
+        },
+        "border": {
+          "radius": {
+            "value": "{rounded.md}",
+            "type": "dimension"
+          },
+          "width": {
+            "value": "{global.2px|0125rem}",
+            "type": "dimension"
+          }
+        },
+        "space": {
+          "p-x": {
+            "value": "{global.14px|0875rem}",
+            "type": "dimension"
+          },
+          "p-y": {
+            "value": "{global.8px|05rem}",
+            "type": "dimension"
+          },
+          "g-x": {
+            "value": "{global.6px|0375rem}",
+            "type": "dimension"
+          },
+          "g-y": {
+            "value": "{global.4px|025rem}",
+            "type": "dimension"
+          }
+        },
+        "icon": {
+          "icon-size": {
+            "value": "{global.24px|1-5rem}",
+            "type": "dimension"
+          }
+        },
+        "indicator": {
+          "border": {
+            "radius": {
+              "value": "{rounded.md}",
+              "type": "dimension"
+            },
+            "width": {
+              "value": "{global.2px|0125rem}",
+              "type": "dimension"
+            }
+          },
+          "padding": {
+            "p-y": {
+              "value": "{global.4px|025rem}",
+              "type": "dimension"
+            },
+            "start-x": {
+              "value": "{global.4px|025rem}",
+              "type": "dimension"
+            },
+            "end-x": {
+              "value": "{global.4px|025rem}",
+              "type": "dimension"
+            }
+          }
+        }
+      },
+      "active": {
+        "text": {
+          "font-weight": {
+            "value": "{font.weight.semibold}",
+            "type": "text"
+          },
+          "font-size": {
+            "value": "{font.size.ui.lg.button}",
+            "type": "dimension"
+          },
+          "line-height": {
+            "value": "{font.line-height.ui.lg.button}",
+            "type": "dimension"
+          }
+        },
+        "border": {
+          "radius": {
+            "value": "{rounded.md}",
+            "type": "dimension"
+          },
+          "width": {
+            "value": "{global.2px|0125rem}",
+            "type": "dimension"
+          }
+        },
+        "space": {
+          "p-x": {
+            "value": "{global.12px|075rem}",
+            "type": "dimension"
+          },
+          "p-y": {
+            "value": "{global.8px|05rem}",
+            "type": "dimension"
+          },
+          "g-x": {
+            "value": "{global.6px|0375rem}",
+            "type": "dimension"
+          },
+          "g-y": {
+            "value": "{global.4px|025rem}",
+            "type": "dimension"
+          }
+        },
+        "icon": {
+          "icon-size": {
+            "value": "{global.24px|1-5rem}",
+            "type": "dimension"
+          }
+        },
+        "indicator": {
+          "border": {
+            "radius": {
+              "value": "{rounded.md}",
+              "type": "dimension"
+            },
+            "width": {
+              "value": "{global.2px|0125rem}",
+              "type": "dimension"
+            }
+          },
+          "padding": {
+            "top-y": {
+              "value": "{global.0}",
+              "type": "dimension"
+            },
+            "start-x": {
+              "value": "{global.0}",
+              "type": "dimension"
+            },
+            "end-x": {
+              "value": "{global.2px|0125rem}",
+              "type": "dimension"
+            },
+            "bottom-y": {
+              "value": "{global.0}",
+              "type": "dimension"
+            }
+          }
+        }
+      },
+      "disabled": {
+        "text": {
+          "font-weight": {
+            "value": "{font.weight.normal}",
+            "type": "text"
+          },
+          "font-size": {
+            "value": "{font.size.ui.lg.button}",
+            "type": "dimension"
+          },
+          "line-height": {
+            "value": "{font.line-height.ui.lg.button}",
+            "type": "dimension"
+          }
+        },
+        "border": {
+          "radius": {
+            "value": "{rounded.md}",
+            "type": "dimension"
+          },
+          "width": {
+            "value": "{global.2px|0125rem}",
+            "type": "dimension"
+          }
+        },
+        "space": {
+          "p-x": {
+            "value": "{padding.p-static.xxxl}",
+            "type": "dimension"
+          },
+          "p-y": {
+            "value": "{padding.p-static.lg}",
+            "type": "dimension"
+          },
+          "g-x": {
+            "value": "{global.6px|0375rem}",
+            "type": "dimension"
+          },
+          "g-y": {
+            "value": "{global.4px|025rem}",
+            "type": "dimension"
+          }
+        },
+        "icon": {
+          "icon-size": {
+            "value": "{global.24px|1-5rem}",
+            "type": "dimension"
+          }
+        },
+        "indicator": {
+          "border": {
+            "radius": {
+              "value": "{rounded.md}",
+              "type": "dimension"
+            },
+            "width": {
+              "value": "{global.0}",
+              "type": "dimension"
+            }
+          },
+          "padding": {
+            "p-y": {
+              "value": "{global.0}",
+              "type": "dimension"
+            },
+            "p-x": {
+              "value": "{global.0}",
+              "type": "dimension"
+            }
+          }
+        }
+      }
+    },
+    "link": {
+      "size": {
+        "value": "{font.size.ui.lg.link}",
+        "type": "dimension"
+      },
+      "line-height": {
+        "value": "{font.line-height.ui.lg.link}",
+        "type": "dimension"
+      },
+      "border-width": {
+        "value": "{border-width.sm}",
+        "type": "dimension"
+      },
+      "letter-spacing-default": {
+        "value": "0rem",
+        "type": "dimension"
+      },
+      "letter-spacing-hover": {
+        "value": "-0.010625000111758709rem",
+        "type": "dimension"
+      },
+      "letter-spacing-focus": {
+        "value": "-0.00937500037252903rem",
+        "type": "dimension"
+      },
+      "letter-spacing-active": {
+        "value": "-0.010625000111758709rem",
+        "type": "dimension"
+      },
+      "letter-spacing-visited": {
+        "value": "-0.010625000111758709rem",
+        "type": "dimension"
+      },
+      "letter-spacing-disabled": {
+        "value": "0.00937500037252903rem",
+        "type": "dimension"
+      },
+      "size-x": {
+        "value": "{font.size.ui.lg.link}",
+        "type": "dimension"
+      },
+      "border-radius": {
+        "value": "{border-width.sm}",
+        "type": "dimension"
+      }
+    },
+    "label": {
+      "line-height": {
+        "value": "{font.line-height.ui.lg.label}",
+        "type": "dimension"
+      },
+      "font-size": {
+        "value": "{font.size.ui.lg.label}",
+        "type": "dimension"
+      }
+    },
+    "placeholder": {
+      "line-height": {
+        "value": "{font.line-height.ui.lg.placeholder}",
+        "type": "dimension"
+      },
+      "font-size": {
+        "value": "{font.size.ui.lg.placeholder}",
+        "type": "dimension"
+      }
+    },
+    "logo": {
+      "line-height": {
+        "value": "{font.line-height.ui.lg.label}",
+        "type": "dimension"
+      },
+      "font-size": {
+        "value": "{font.size.ui.lg.label}",
+        "type": "dimension"
+      },
+      "icon-size-pair": {
+        "value": "0rem",
+        "type": "dimension"
+      },
+      "icon-size": {
+        "value": "0rem",
+        "type": "dimension"
+      },
+      "g-x": {
+        "value": "0rem",
+        "type": "dimension"
+      },
+      "g-y": {
+        "value": "0rem",
+        "type": "dimension"
+      }
+    },
+    "nav-item": {
+      "line-height": {
+        "value": "{font.line-height.ui.lg.label}",
+        "type": "dimension"
+      },
+      "font-size": {
+        "value": "{font.size.ui.lg.label}",
+        "type": "dimension"
+      }
+    },
+    "pull-quote": {
+      "line-height": {
+        "value": "{font.line-height.ui.lg.placeholder}",
+        "type": "dimension"
+      },
+      "font-size": {
+        "value": "{font.size.ui.lg.placeholder}",
+        "type": "dimension"
+      }
+    },
+    "tool-tip": {
+      "line-height": {
+        "value": "{font.line-height.ui.lg.placeholder}",
+        "type": "dimension"
+      },
+      "font-size": {
+        "value": "{font.size.ui.lg.placeholder}",
+        "type": "dimension"
+      }
+    },
+    "counter": {
+      "line-height": {
+        "value": "{font.line-height.ui.lg.counter}",
+        "type": "dimension"
+      },
+      "font-size": {
+        "value": "{font.size.ui.lg.counter}",
+        "type": "dimension"
+      }
+    }
+  },
+  "interaction-values/default": {
+    "is-default": {
+      "value": "true",
+      "type": "boolean"
+    },
+    "is-active": {
+      "value": "false",
+      "type": "boolean"
+    },
+    "is default": {
+      "value": "{is-default}",
+      "type": "boolean"
+    },
+    "is-required": {
+      "value": "false",
+      "type": "boolean"
+    },
+    "action": {
+      "vote": {
+        "value": "Upvote",
+        "type": "text"
+      },
+      "like": {
+        "value": "Like",
+        "type": "text"
+      },
+      "share": {
+        "value": "Share",
+        "type": "text"
+      },
+      "save": {
+        "value": "Save",
+        "type": "text"
+      },
+      "comment": {
+        "value": "Comment",
+        "type": "text"
+      }
+    },
+    "num": {
+      "count": {
+        "value": "0rem",
+        "type": "dimension"
+      },
+      "count-empty": {
+        "value": "0rem",
+        "type": "dimension"
+      },
+      "count-sample": {
+        "value": "2.75rem",
+        "type": "dimension"
+      }
+    }
+  },
+  "interaction-values/interacted": {
+    "is-default": {
+      "value": "false",
+      "type": "boolean"
+    },
+    "is-active": {
+      "value": "true",
+      "type": "boolean"
+    },
+    "is default": {
+      "value": "{is-default}",
+      "type": "boolean"
+    },
+    "is-required": {
+      "value": "false",
+      "type": "boolean"
+    },
+    "action": {
+      "vote": {
+        "value": "Upvoted",
+        "type": "text"
+      },
+      "like": {
+        "value": "Liked",
+        "type": "text"
+      },
+      "share": {
+        "value": "Shared",
+        "type": "text"
+      },
+      "save": {
+        "value": "Saved",
+        "type": "text"
+      },
+      "comment": {
+        "value": "Commented",
+        "type": "text"
+      }
+    },
+    "num": {
+      "count": {
+        "value": "0rem",
+        "type": "dimension"
+      },
+      "count-empty": {
+        "value": "0.0625rem",
+        "type": "dimension"
+      },
+      "count-sample": {
+        "value": "2.8125rem",
+        "type": "dimension"
+      }
+    }
+  },
+  "text-primitives/static": {
+    "font": {
+      "family": {
+        "primary": {
+          "value": "Oswald",
+          "type": "text"
+        },
+        "secondary": {
+          "value": "Nunito Sans",
+          "type": "text"
+        }
+      },
+      "weight": {
+        "extralight": {
+          "value": "ExtraLight",
+          "type": "text"
+        },
+        "light": {
+          "value": "Light",
+          "type": "text"
+        },
+        "normal": {
+          "value": "Regular",
+          "type": "text"
+        },
+        "medium": {
+          "value": "Medium",
+          "type": "text"
+        },
+        "semibold": {
+          "value": "SemiBold",
+          "type": "text"
+        },
+        "bold": {
+          "value": "Bold",
+          "type": "text"
+        }
+      },
+      "style-italic": {
+        "extralight": {
+          "value": "ExtraLight Italic",
+          "type": "text"
+        },
+        "light": {
+          "value": "Light Italic",
+          "type": "text"
+        },
+        "normal": {
+          "value": "Italic",
+          "type": "text"
+        },
+        "semibold": {
+          "value": "SemiBold Italic",
+          "type": "text"
+        }
+      }
+    }
+  },
+  "num-responsive/mobile": {
+    "global": {
+      "0": {
+        "value": "0rem",
+        "type": "dimension"
+      },
+      "2px|0125rem": {
+        "value": "0.125rem",
+        "type": "dimension"
+      },
+      "4px|025rem": {
+        "value": "0.25rem",
+        "type": "dimension"
+      },
+      "8px|05rem": {
+        "value": "0.5rem",
+        "type": "dimension"
+      },
+      "12px|075rem": {
+        "value": "0.75rem",
+        "type": "dimension"
+      },
+      "16px|1rem": {
+        "value": "1rem",
+        "type": "dimension"
+      },
+      "20px|1-25rem": {
+        "value": "1.25rem",
+        "type": "dimension"
+      },
+      "24px|1-5rem": {
+        "value": "1.5rem",
+        "type": "dimension"
+      },
+      "28px|1-75rem": {
+        "value": "1.75rem",
+        "type": "dimension"
+      },
+      "32px|2rem": {
+        "value": "2rem",
+        "type": "dimension"
+      },
+      "36px|2-25rem": {
+        "value": "2.25rem",
+        "type": "dimension"
+      },
+      "40px|2-5rem": {
+        "value": "2.5rem",
+        "type": "dimension"
+      },
+      "44px|2-75rem": {
+        "value": "2.75rem",
+        "type": "dimension"
+      },
+      "48px|3rem": {
+        "value": "3rem",
+        "type": "dimension"
+      },
+      "52px|3-25rem": {
+        "value": "3.25rem",
+        "type": "dimension"
+      },
+      "56px|3-5rem": {
+        "value": "3.5rem",
+        "type": "dimension"
+      },
+      "60px|3-75rem": {
+        "value": "3.75rem",
+        "type": "dimension"
+      },
+      "64px|4rem": {
+        "value": "4rem",
+        "type": "dimension"
+      },
+      "68px|4-25rem": {
+        "value": "4.25rem",
+        "type": "dimension"
+      },
+      "72px|4-5rem": {
+        "value": "4.5rem",
+        "type": "dimension"
+      },
+      "76px|4-75rem": {
+        "value": "4.75rem",
+        "type": "dimension"
+      },
+      "80px|5rem": {
+        "value": "5rem",
+        "type": "dimension"
+      },
+      "84px|5-25rem": {
+        "value": "5.25rem",
+        "type": "dimension"
+      },
+      "88px|5-5rem": {
+        "value": "5.5rem",
+        "type": "dimension"
+      },
+      "92px|5-75rem": {
+        "value": "5.75rem",
+        "type": "dimension"
+      },
+      "96px|6rem": {
+        "value": "6rem",
+        "type": "dimension"
+      },
+      "100px|6-25rem": {
+        "value": "6.25rem",
+        "type": "dimension"
+      },
+      "104px|6-5rem": {
+        "value": "6.5rem",
+        "type": "dimension"
+      },
+      "108px|6-75rem": {
+        "value": "6.75rem",
+        "type": "dimension"
+      },
+      "112px|7rem": {
+        "value": "7rem",
+        "type": "dimension"
+      },
+      "116px|7-25rem": {
+        "value": "7.25rem",
+        "type": "dimension"
+      },
+      "120px|7-5rem": {
+        "value": "7.5rem",
+        "type": "dimension"
+      },
+      "128px|8rem": {
+        "value": "8rem",
+        "type": "dimension"
+      },
+      "14px|0875rem": {
+        "value": "0.875rem",
+        "type": "dimension"
+      },
+      "18px|089rem": {
+        "value": "1.125rem",
+        "type": "dimension"
+      },
+      "6px|0375rem": {
+        "value": "0.375rem",
+        "type": "dimension"
+      },
+      "256px|16rem": {
+        "value": "16rem",
+        "type": "dimension"
+      },
+      "400px|25rem": {
+        "value": "25rem",
+        "type": "dimension"
+      }
+    },
+    "viewport": {
+      "v-w": {
+        "w": {
+          "value": "22.5rem",
+          "type": "dimension"
+        },
+        "min-w": {
+          "value": "20rem",
+          "type": "dimension"
+        },
+        "max-w": {
+          "value": "40rem",
+          "type": "dimension"
+        }
+      },
+      "v-h": {
+        "h": {
+          "value": "50rem",
+          "type": "dimension"
+        },
+        "min-h": {
+          "value": "31.875rem",
+          "type": "dimension"
+        },
+        "max-h": {
+          "value": "63.75rem",
+          "type": "dimension"
+        }
+      }
+    },
+    "gap": {
+      "0": {
+        "value": "0rem",
+        "type": "dimension"
+      },
+      "g-x": {
+        "0": {
+          "value": "0rem",
+          "type": "dimension"
+        },
+        "xs": {
+          "value": "{global.4px|025rem}",
+          "type": "dimension"
+        },
+        "sm": {
+          "value": "{global.8px|05rem}",
+          "type": "dimension"
+        },
+        "md": {
+          "value": "{global.16px|1rem}",
+          "type": "dimension"
+        },
+        "lg": {
+          "value": "{global.24px|1-5rem}",
+          "type": "dimension"
+        },
+        "xl": {
+          "value": "{global.32px|2rem}",
+          "type": "dimension"
+        }
+      },
+      "g-y": {
+        "0": {
+          "value": "0rem",
+          "type": "dimension"
+        },
+        "xs": {
+          "value": "{global.4px|025rem}",
+          "type": "dimension"
+        },
+        "sm": {
+          "value": "{global.8px|05rem}",
+          "type": "dimension"
+        },
+        "md": {
+          "value": "{global.16px|1rem}",
+          "type": "dimension"
+        },
+        "lg": {
+          "value": "{global.24px|1-5rem}",
+          "type": "dimension"
+        },
+        "xl": {
+          "value": "{global.32px|2rem}",
+          "type": "dimension"
+        }
+      }
+    },
+    "padding": {
+      "0": {
+        "value": "0rem",
+        "type": "dimension"
+      },
+      "p-y": {
+        "0": {
+          "value": "0rem",
+          "type": "dimension"
+        },
+        "xs": {
+          "value": "{global.8px|05rem}",
+          "type": "dimension"
+        },
+        "sm": {
+          "value": "{global.16px|1rem}",
+          "type": "dimension"
+        },
+        "md": {
+          "value": "{global.24px|1-5rem}",
+          "type": "dimension"
+        },
+        "lg": {
+          "value": "{global.32px|2rem}",
+          "type": "dimension"
+        },
+        "xl": {
+          "value": "{global.48px|3rem}",
+          "type": "dimension"
+        }
+      },
+      "p-x": {
+        "0": {
+          "value": "0rem",
+          "type": "dimension"
+        },
+        "xs": {
+          "value": "{global.8px|05rem}",
+          "type": "dimension"
+        },
+        "sm": {
+          "value": "{global.16px|1rem}",
+          "type": "dimension"
+        },
+        "md": {
+          "value": "{global.24px|1-5rem}",
+          "type": "dimension"
+        },
+        "lg": {
+          "value": "{global.32px|2rem}",
+          "type": "dimension"
+        },
+        "xl": {
+          "value": "{global.48px|3rem}",
+          "type": "dimension"
+        }
+      }
+    },
+    "text": {
+      "xs": {
+        "value": "{global.12px|075rem}",
+        "type": "dimension"
+      },
+      "sm": {
+        "value": "{global.14px|0875rem}",
+        "type": "dimension"
+      },
+      "base": {
+        "value": "{global.16px|1rem}",
+        "type": "dimension"
+      },
+      "lg": {
+        "value": "{global.18px|089rem}",
+        "type": "dimension"
+      },
+      "xl": {
+        "value": "{global.20px|1-25rem}",
+        "type": "dimension"
+      },
+      "2xl": {
+        "value": "{global.24px|1-5rem}",
+        "type": "dimension"
+      },
+      "3xl": {
+        "value": "{global.32px|2rem}",
+        "type": "dimension"
+      },
+      "4xl": {
+        "value": "{global.40px|2-5rem}",
+        "type": "dimension"
+      },
+      "5xl": {
+        "value": "{global.48px|3rem}",
+        "type": "dimension"
+      },
+      "6xl": {
+        "value": "{global.56px|3-5rem}",
+        "type": "dimension"
+      }
+    },
+    "border-width": {
+      "none": {
+        "value": "{global.0}",
+        "type": "dimension"
+      },
+      "sm": {
+        "value": "{global.2px|0125rem}",
+        "type": "dimension"
+      },
+      "base": {
+        "value": "{global.4px|025rem}",
+        "type": "dimension"
+      },
+      "lg": {
+        "value": "{global.4px|025rem}",
+        "type": "dimension"
+      }
+    },
+    "rounded": {
+      "none": {
+        "value": "{global.0}",
+        "type": "dimension"
+      },
+      "sm": {
+        "value": "{global.2px|0125rem}",
+        "type": "dimension"
+      },
+      "2xl": {
+        "value": "{global.16px|1rem}",
+        "type": "dimension"
+      },
+      "3xl": {
+        "value": "{global.24px|1-5rem}",
+        "type": "dimension"
+      },
+      "base": {
+        "value": "{global.4px|025rem}",
+        "type": "dimension"
+      },
+      "md": {
+        "value": "{global.6px|0375rem}",
+        "type": "dimension"
+      },
+      "lg": {
+        "value": "{global.8px|05rem}",
+        "type": "dimension"
+      },
+      "xl": {
+        "value": "{global.12px|075rem}",
+        "type": "dimension"
+      },
+      "full": {
+        "value": "624.9375rem",
+        "type": "dimension"
+      }
+    },
+    "margin": {
+      "m-y": {
+        "0": {
+          "value": "0rem",
+          "type": "dimension"
+        },
+        "xs": {
+          "value": "{global.8px|05rem}",
+          "type": "dimension"
+        },
+        "sm": {
+          "value": "{global.16px|1rem}",
+          "type": "dimension"
+        },
+        "md": {
+          "value": "{global.24px|1-5rem}",
+          "type": "dimension"
+        },
+        "lg": {
+          "value": "{global.32px|2rem}",
+          "type": "dimension"
+        },
+        "xl": {
+          "value": "{global.48px|3rem}",
+          "type": "dimension"
+        }
+      },
+      "m-x": {
+        "0": {
+          "value": "0rem",
+          "type": "dimension"
+        },
+        "xs": {
+          "value": "{global.8px|05rem}",
+          "type": "dimension"
+        },
+        "sm": {
+          "value": "{global.16px|1rem}",
+          "type": "dimension"
+        },
+        "md": {
+          "value": "{global.24px|1-5rem}",
+          "type": "dimension"
+        },
+        "lg": {
+          "value": "{global.32px|2rem}",
+          "type": "dimension"
+        },
+        "xl": {
+          "value": "{global.48px|3rem}",
+          "type": "dimension"
+        }
+      }
+    }
+  },
+  "num-responsive/tablet": {
+    "global": {
+      "0": {
+        "value": "0rem",
+        "type": "dimension"
+      },
+      "2px|0125rem": {
+        "value": "0.125rem",
+        "type": "dimension"
+      },
+      "4px|025rem": {
+        "value": "0.25rem",
+        "type": "dimension"
+      },
+      "8px|05rem": {
+        "value": "0.5rem",
+        "type": "dimension"
+      },
+      "12px|075rem": {
+        "value": "0.75rem",
+        "type": "dimension"
+      },
+      "16px|1rem": {
+        "value": "1rem",
+        "type": "dimension"
+      },
+      "20px|1-25rem": {
+        "value": "1.25rem",
+        "type": "dimension"
+      },
+      "24px|1-5rem": {
+        "value": "1.5rem",
+        "type": "dimension"
+      },
+      "28px|1-75rem": {
+        "value": "1.75rem",
+        "type": "dimension"
+      },
+      "32px|2rem": {
+        "value": "2rem",
+        "type": "dimension"
+      },
+      "36px|2-25rem": {
+        "value": "2.25rem",
+        "type": "dimension"
+      },
+      "40px|2-5rem": {
+        "value": "2.5rem",
+        "type": "dimension"
+      },
+      "44px|2-75rem": {
+        "value": "2.75rem",
+        "type": "dimension"
+      },
+      "48px|3rem": {
+        "value": "3rem",
+        "type": "dimension"
+      },
+      "52px|3-25rem": {
+        "value": "3.25rem",
+        "type": "dimension"
+      },
+      "56px|3-5rem": {
+        "value": "3.5rem",
+        "type": "dimension"
+      },
+      "60px|3-75rem": {
+        "value": "3.75rem",
+        "type": "dimension"
+      },
+      "64px|4rem": {
+        "value": "4rem",
+        "type": "dimension"
+      },
+      "68px|4-25rem": {
+        "value": "4.25rem",
+        "type": "dimension"
+      },
+      "72px|4-5rem": {
+        "value": "4.5rem",
+        "type": "dimension"
+      },
+      "76px|4-75rem": {
+        "value": "4.75rem",
+        "type": "dimension"
+      },
+      "80px|5rem": {
+        "value": "5rem",
+        "type": "dimension"
+      },
+      "84px|5-25rem": {
+        "value": "5.25rem",
+        "type": "dimension"
+      },
+      "88px|5-5rem": {
+        "value": "5.5rem",
+        "type": "dimension"
+      },
+      "92px|5-75rem": {
+        "value": "5.75rem",
+        "type": "dimension"
+      },
+      "96px|6rem": {
+        "value": "6rem",
+        "type": "dimension"
+      },
+      "100px|6-25rem": {
+        "value": "6.25rem",
+        "type": "dimension"
+      },
+      "104px|6-5rem": {
+        "value": "6.5rem",
+        "type": "dimension"
+      },
+      "108px|6-75rem": {
+        "value": "6.75rem",
+        "type": "dimension"
+      },
+      "112px|7rem": {
+        "value": "7rem",
+        "type": "dimension"
+      },
+      "116px|7-25rem": {
+        "value": "7.25rem",
+        "type": "dimension"
+      },
+      "120px|7-5rem": {
+        "value": "7.5rem",
+        "type": "dimension"
+      },
+      "128px|8rem": {
+        "value": "8rem",
+        "type": "dimension"
+      },
+      "14px|0875rem": {
+        "value": "0.875rem",
+        "type": "dimension"
+      },
+      "18px|089rem": {
+        "value": "1.125rem",
+        "type": "dimension"
+      },
+      "6px|0375rem": {
+        "value": "0.375rem",
+        "type": "dimension"
+      },
+      "256px|16rem": {
+        "value": "16rem",
+        "type": "dimension"
+      },
+      "400px|25rem": {
+        "value": "25rem",
+        "type": "dimension"
+      }
+    },
+    "viewport": {
+      "v-w": {
+        "w": {
+          "value": "48rem",
+          "type": "dimension"
+        },
+        "min-w": {
+          "value": "40rem",
+          "type": "dimension"
+        },
+        "max-w": {
+          "value": "64rem",
+          "type": "dimension"
+        }
+      },
+      "v-h": {
+        "h": {
+          "value": "64rem",
+          "type": "dimension"
+        },
+        "min-h": {
+          "value": "48rem",
+          "type": "dimension"
+        },
+        "max-h": {
+          "value": "64rem",
+          "type": "dimension"
+        }
+      }
+    },
+    "gap": {
+      "0": {
+        "value": "0rem",
+        "type": "dimension"
+      },
+      "g-x": {
+        "0": {
+          "value": "0rem",
+          "type": "dimension"
+        },
+        "xs": {
+          "value": "{global.4px|025rem}",
+          "type": "dimension"
+        },
+        "sm": {
+          "value": "{global.8px|05rem}",
+          "type": "dimension"
+        },
+        "md": {
+          "value": "{global.16px|1rem}",
+          "type": "dimension"
+        },
+        "lg": {
+          "value": "{global.24px|1-5rem}",
+          "type": "dimension"
+        },
+        "xl": {
+          "value": "{global.32px|2rem}",
+          "type": "dimension"
+        }
+      },
+      "g-y": {
+        "0": {
+          "value": "0rem",
+          "type": "dimension"
+        },
+        "xs": {
+          "value": "{global.4px|025rem}",
+          "type": "dimension"
+        },
+        "sm": {
+          "value": "{global.8px|05rem}",
+          "type": "dimension"
+        },
+        "md": {
+          "value": "{global.16px|1rem}",
+          "type": "dimension"
+        },
+        "lg": {
+          "value": "{global.24px|1-5rem}",
+          "type": "dimension"
+        },
+        "xl": {
+          "value": "{global.32px|2rem}",
+          "type": "dimension"
+        }
+      }
+    },
+    "padding": {
+      "0": {
+        "value": "0rem",
+        "type": "dimension"
+      },
+      "p-y": {
+        "0": {
+          "value": "0rem",
+          "type": "dimension"
+        },
+        "xs": {
+          "value": "{global.8px|05rem}",
+          "type": "dimension"
+        },
+        "sm": {
+          "value": "{global.16px|1rem}",
+          "type": "dimension"
+        },
+        "md": {
+          "value": "{global.24px|1-5rem}",
+          "type": "dimension"
+        },
+        "lg": {
+          "value": "{global.32px|2rem}",
+          "type": "dimension"
+        },
+        "xl": {
+          "value": "{global.48px|3rem}",
+          "type": "dimension"
+        }
+      },
+      "p-x": {
+        "0": {
+          "value": "0rem",
+          "type": "dimension"
+        },
+        "xs": {
+          "value": "{global.8px|05rem}",
+          "type": "dimension"
+        },
+        "sm": {
+          "value": "{global.16px|1rem}",
+          "type": "dimension"
+        },
+        "md": {
+          "value": "{global.24px|1-5rem}",
+          "type": "dimension"
+        },
+        "lg": {
+          "value": "{global.32px|2rem}",
+          "type": "dimension"
+        },
+        "xl": {
+          "value": "{global.48px|3rem}",
+          "type": "dimension"
+        }
+      }
+    },
+    "text": {
+      "xs": {
+        "value": "{global.12px|075rem}",
+        "type": "dimension"
+      },
+      "sm": {
+        "value": "{global.14px|0875rem}",
+        "type": "dimension"
+      },
+      "base": {
+        "value": "{global.16px|1rem}",
+        "type": "dimension"
+      },
+      "lg": {
+        "value": "{global.18px|089rem}",
+        "type": "dimension"
+      },
+      "xl": {
+        "value": "{global.20px|1-25rem}",
+        "type": "dimension"
+      },
+      "2xl": {
+        "value": "{global.24px|1-5rem}",
+        "type": "dimension"
+      },
+      "3xl": {
+        "value": "{global.32px|2rem}",
+        "type": "dimension"
+      },
+      "4xl": {
+        "value": "{global.40px|2-5rem}",
+        "type": "dimension"
+      },
+      "5xl": {
+        "value": "{global.48px|3rem}",
+        "type": "dimension"
+      },
+      "6xl": {
+        "value": "{global.56px|3-5rem}",
+        "type": "dimension"
+      }
+    },
+    "border-width": {
+      "none": {
+        "value": "{global.0}",
+        "type": "dimension"
+      },
+      "sm": {
+        "value": "{global.2px|0125rem}",
+        "type": "dimension"
+      },
+      "base": {
+        "value": "{global.4px|025rem}",
+        "type": "dimension"
+      },
+      "lg": {
+        "value": "{global.4px|025rem}",
+        "type": "dimension"
+      }
+    },
+    "rounded": {
+      "none": {
+        "value": "{global.0}",
+        "type": "dimension"
+      },
+      "sm": {
+        "value": "{global.2px|0125rem}",
+        "type": "dimension"
+      },
+      "2xl": {
+        "value": "{global.16px|1rem}",
+        "type": "dimension"
+      },
+      "3xl": {
+        "value": "{global.24px|1-5rem}",
+        "type": "dimension"
+      },
+      "base": {
+        "value": "{global.4px|025rem}",
+        "type": "dimension"
+      },
+      "md": {
+        "value": "{global.6px|0375rem}",
+        "type": "dimension"
+      },
+      "lg": {
+        "value": "{global.8px|05rem}",
+        "type": "dimension"
+      },
+      "xl": {
+        "value": "{global.12px|075rem}",
+        "type": "dimension"
+      },
+      "full": {
+        "value": "624.9375rem",
+        "type": "dimension"
+      }
+    },
+    "margin": {
+      "m-y": {
+        "0": {
+          "value": "0rem",
+          "type": "dimension"
+        },
+        "xs": {
+          "value": "{global.8px|05rem}",
+          "type": "dimension"
+        },
+        "sm": {
+          "value": "{global.16px|1rem}",
+          "type": "dimension"
+        },
+        "md": {
+          "value": "{global.24px|1-5rem}",
+          "type": "dimension"
+        },
+        "lg": {
+          "value": "{global.32px|2rem}",
+          "type": "dimension"
+        },
+        "xl": {
+          "value": "{global.48px|3rem}",
+          "type": "dimension"
+        }
+      },
+      "m-x": {
+        "0": {
+          "value": "0rem",
+          "type": "dimension"
+        },
+        "xs": {
+          "value": "{global.8px|05rem}",
+          "type": "dimension"
+        },
+        "sm": {
+          "value": "{global.16px|1rem}",
+          "type": "dimension"
+        },
+        "md": {
+          "value": "{global.24px|1-5rem}",
+          "type": "dimension"
+        },
+        "lg": {
+          "value": "{global.32px|2rem}",
+          "type": "dimension"
+        },
+        "xl": {
+          "value": "{global.48px|3rem}",
+          "type": "dimension"
+        }
+      }
+    }
+  },
+  "num-responsive/laptop": {
+    "global": {
+      "0": {
+        "value": "0rem",
+        "type": "dimension"
+      },
+      "2px|0125rem": {
+        "value": "0.125rem",
+        "type": "dimension"
+      },
+      "4px|025rem": {
+        "value": "0.25rem",
+        "type": "dimension"
+      },
+      "8px|05rem": {
+        "value": "0.5rem",
+        "type": "dimension"
+      },
+      "12px|075rem": {
+        "value": "0.75rem",
+        "type": "dimension"
+      },
+      "16px|1rem": {
+        "value": "1rem",
+        "type": "dimension"
+      },
+      "20px|1-25rem": {
+        "value": "1.25rem",
+        "type": "dimension"
+      },
+      "24px|1-5rem": {
+        "value": "1.5rem",
+        "type": "dimension"
+      },
+      "28px|1-75rem": {
+        "value": "1.75rem",
+        "type": "dimension"
+      },
+      "32px|2rem": {
+        "value": "2rem",
+        "type": "dimension"
+      },
+      "36px|2-25rem": {
+        "value": "2.25rem",
+        "type": "dimension"
+      },
+      "40px|2-5rem": {
+        "value": "2.5rem",
+        "type": "dimension"
+      },
+      "44px|2-75rem": {
+        "value": "2.75rem",
+        "type": "dimension"
+      },
+      "48px|3rem": {
+        "value": "3rem",
+        "type": "dimension"
+      },
+      "52px|3-25rem": {
+        "value": "3.25rem",
+        "type": "dimension"
+      },
+      "56px|3-5rem": {
+        "value": "3.5rem",
+        "type": "dimension"
+      },
+      "60px|3-75rem": {
+        "value": "3.75rem",
+        "type": "dimension"
+      },
+      "64px|4rem": {
+        "value": "4rem",
+        "type": "dimension"
+      },
+      "68px|4-25rem": {
+        "value": "4.25rem",
+        "type": "dimension"
+      },
+      "72px|4-5rem": {
+        "value": "4.5rem",
+        "type": "dimension"
+      },
+      "76px|4-75rem": {
+        "value": "4.75rem",
+        "type": "dimension"
+      },
+      "80px|5rem": {
+        "value": "5rem",
+        "type": "dimension"
+      },
+      "84px|5-25rem": {
+        "value": "5.25rem",
+        "type": "dimension"
+      },
+      "88px|5-5rem": {
+        "value": "5.5rem",
+        "type": "dimension"
+      },
+      "92px|5-75rem": {
+        "value": "5.75rem",
+        "type": "dimension"
+      },
+      "96px|6rem": {
+        "value": "6rem",
+        "type": "dimension"
+      },
+      "100px|6-25rem": {
+        "value": "6.25rem",
+        "type": "dimension"
+      },
+      "104px|6-5rem": {
+        "value": "6.5rem",
+        "type": "dimension"
+      },
+      "108px|6-75rem": {
+        "value": "6.75rem",
+        "type": "dimension"
+      },
+      "112px|7rem": {
+        "value": "7rem",
+        "type": "dimension"
+      },
+      "116px|7-25rem": {
+        "value": "7.25rem",
+        "type": "dimension"
+      },
+      "120px|7-5rem": {
+        "value": "7.5rem",
+        "type": "dimension"
+      },
+      "128px|8rem": {
+        "value": "8rem",
+        "type": "dimension"
+      },
+      "14px|0875rem": {
+        "value": "0.875rem",
+        "type": "dimension"
+      },
+      "18px|089rem": {
+        "value": "1.125rem",
+        "type": "dimension"
+      },
+      "6px|0375rem": {
+        "value": "0.375rem",
+        "type": "dimension"
+      },
+      "256px|16rem": {
+        "value": "16rem",
+        "type": "dimension"
+      },
+      "400px|25rem": {
+        "value": "25rem",
+        "type": "dimension"
+      }
+    },
+    "viewport": {
+      "v-w": {
+        "w": {
+          "value": "80rem",
+          "type": "dimension"
+        },
+        "min-w": {
+          "value": "64rem",
+          "type": "dimension"
+        },
+        "max-w": {
+          "value": "90rem",
+          "type": "dimension"
+        }
+      },
+      "v-h": {
+        "h": {
+          "value": "52rem",
+          "type": "dimension"
+        },
+        "min-h": {
+          "value": "48rem",
+          "type": "dimension"
+        },
+        "max-h": {
+          "value": "52rem",
+          "type": "dimension"
+        }
+      }
+    },
+    "gap": {
+      "0": {
+        "value": "0rem",
+        "type": "dimension"
+      },
+      "g-x": {
+        "0": {
+          "value": "0rem",
+          "type": "dimension"
+        },
+        "xs": {
+          "value": "{global.8px|05rem}",
+          "type": "dimension"
+        },
+        "sm": {
+          "value": "{global.16px|1rem}",
+          "type": "dimension"
+        },
+        "md": {
+          "value": "{global.24px|1-5rem}",
+          "type": "dimension"
+        },
+        "lg": {
+          "value": "{global.32px|2rem}",
+          "type": "dimension"
+        },
+        "xl": {
+          "value": "{global.64px|4rem}",
+          "type": "dimension"
+        }
+      },
+      "g-y": {
+        "0": {
+          "value": "0rem",
+          "type": "dimension"
+        },
+        "xs": {
+          "value": "{global.8px|05rem}",
+          "type": "dimension"
+        },
+        "sm": {
+          "value": "{global.16px|1rem}",
+          "type": "dimension"
+        },
+        "md": {
+          "value": "{global.24px|1-5rem}",
+          "type": "dimension"
+        },
+        "lg": {
+          "value": "{global.32px|2rem}",
+          "type": "dimension"
+        },
+        "xl": {
+          "value": "{global.64px|4rem}",
+          "type": "dimension"
+        }
+      }
+    },
+    "padding": {
+      "0": {
+        "value": "0rem",
+        "type": "dimension"
+      },
+      "p-y": {
+        "0": {
+          "value": "0rem",
+          "type": "dimension"
+        },
+        "xs": {
+          "value": "{global.24px|1-5rem}",
+          "type": "dimension"
+        },
+        "sm": {
+          "value": "{global.48px|3rem}",
+          "type": "dimension"
+        },
+        "md": {
+          "value": "{global.64px|4rem}",
+          "type": "dimension"
+        },
+        "lg": {
+          "value": "{global.96px|6rem}",
+          "type": "dimension"
+        },
+        "xl": {
+          "value": "{global.128px|8rem}",
+          "type": "dimension"
+        }
+      },
+      "p-x": {
+        "0": {
+          "value": "0rem",
+          "type": "dimension"
+        },
+        "xs": {
+          "value": "{global.24px|1-5rem}",
+          "type": "dimension"
+        },
+        "sm": {
+          "value": "{global.48px|3rem}",
+          "type": "dimension"
+        },
+        "md": {
+          "value": "{global.64px|4rem}",
+          "type": "dimension"
+        },
+        "lg": {
+          "value": "{global.96px|6rem}",
+          "type": "dimension"
+        },
+        "xl": {
+          "value": "{global.128px|8rem}",
+          "type": "dimension"
+        }
+      }
+    },
+    "text": {
+      "xs": {
+        "value": "{global.12px|075rem}",
+        "type": "dimension"
+      },
+      "sm": {
+        "value": "{global.14px|0875rem}",
+        "type": "dimension"
+      },
+      "base": {
+        "value": "{global.16px|1rem}",
+        "type": "dimension"
+      },
+      "lg": {
+        "value": "{global.20px|1-25rem}",
+        "type": "dimension"
+      },
+      "xl": {
+        "value": "{global.24px|1-5rem}",
+        "type": "dimension"
+      },
+      "2xl": {
+        "value": "{global.32px|2rem}",
+        "type": "dimension"
+      },
+      "3xl": {
+        "value": "{global.40px|2-5rem}",
+        "type": "dimension"
+      },
+      "4xl": {
+        "value": "{global.48px|3rem}",
+        "type": "dimension"
+      },
+      "5xl": {
+        "value": "{global.56px|3-5rem}",
+        "type": "dimension"
+      },
+      "6xl": {
+        "value": "{global.64px|4rem}",
+        "type": "dimension"
+      }
+    },
+    "border-width": {
+      "none": {
+        "value": "{global.0}",
+        "type": "dimension"
+      },
+      "sm": {
+        "value": "{global.4px|025rem}",
+        "type": "dimension"
+      },
+      "base": {
+        "value": "{global.4px|025rem}",
+        "type": "dimension"
+      },
+      "lg": {
+        "value": "{global.8px|05rem}",
+        "type": "dimension"
+      }
+    },
+    "rounded": {
+      "none": {
+        "value": "{global.0}",
+        "type": "dimension"
+      },
+      "sm": {
+        "value": "{global.2px|0125rem}",
+        "type": "dimension"
+      },
+      "2xl": {
+        "value": "{global.16px|1rem}",
+        "type": "dimension"
+      },
+      "3xl": {
+        "value": "{global.24px|1-5rem}",
+        "type": "dimension"
+      },
+      "base": {
+        "value": "{global.4px|025rem}",
+        "type": "dimension"
+      },
+      "md": {
+        "value": "{global.6px|0375rem}",
+        "type": "dimension"
+      },
+      "lg": {
+        "value": "{global.8px|05rem}",
+        "type": "dimension"
+      },
+      "xl": {
+        "value": "{global.12px|075rem}",
+        "type": "dimension"
+      },
+      "full": {
+        "value": "624.9375rem",
+        "type": "dimension"
+      }
+    },
+    "margin": {
+      "m-y": {
+        "0": {
+          "value": "0rem",
+          "type": "dimension"
+        },
+        "xs": {
+          "value": "{global.16px|1rem}",
+          "type": "dimension"
+        },
+        "sm": {
+          "value": "{global.24px|1-5rem}",
+          "type": "dimension"
+        },
+        "md": {
+          "value": "{global.32px|2rem}",
+          "type": "dimension"
+        },
+        "lg": {
+          "value": "{global.48px|3rem}",
+          "type": "dimension"
+        },
+        "xl": {
+          "value": "{global.56px|3-5rem}",
+          "type": "dimension"
+        }
+      },
+      "m-x": {
+        "0": {
+          "value": "0rem",
+          "type": "dimension"
+        },
+        "xs": {
+          "value": "{global.16px|1rem}",
+          "type": "dimension"
+        },
+        "sm": {
+          "value": "{global.24px|1-5rem}",
+          "type": "dimension"
+        },
+        "md": {
+          "value": "{global.32px|2rem}",
+          "type": "dimension"
+        },
+        "lg": {
+          "value": "{global.48px|3rem}",
+          "type": "dimension"
+        },
+        "xl": {
+          "value": "{global.56px|3-5rem}",
+          "type": "dimension"
+        }
+      }
+    }
+  },
+  "num-responsive/desktop": {
+    "global": {
+      "0": {
+        "value": "0rem",
+        "type": "dimension"
+      },
+      "2px|0125rem": {
+        "value": "0.125rem",
+        "type": "dimension"
+      },
+      "4px|025rem": {
+        "value": "0.25rem",
+        "type": "dimension"
+      },
+      "8px|05rem": {
+        "value": "0.5rem",
+        "type": "dimension"
+      },
+      "12px|075rem": {
+        "value": "0.75rem",
+        "type": "dimension"
+      },
+      "16px|1rem": {
+        "value": "1rem",
+        "type": "dimension"
+      },
+      "20px|1-25rem": {
+        "value": "1.25rem",
+        "type": "dimension"
+      },
+      "24px|1-5rem": {
+        "value": "1.5rem",
+        "type": "dimension"
+      },
+      "28px|1-75rem": {
+        "value": "1.75rem",
+        "type": "dimension"
+      },
+      "32px|2rem": {
+        "value": "2rem",
+        "type": "dimension"
+      },
+      "36px|2-25rem": {
+        "value": "2.25rem",
+        "type": "dimension"
+      },
+      "40px|2-5rem": {
+        "value": "2.5rem",
+        "type": "dimension"
+      },
+      "44px|2-75rem": {
+        "value": "2.75rem",
+        "type": "dimension"
+      },
+      "48px|3rem": {
+        "value": "3rem",
+        "type": "dimension"
+      },
+      "52px|3-25rem": {
+        "value": "3.25rem",
+        "type": "dimension"
+      },
+      "56px|3-5rem": {
+        "value": "3.5rem",
+        "type": "dimension"
+      },
+      "60px|3-75rem": {
+        "value": "3.75rem",
+        "type": "dimension"
+      },
+      "64px|4rem": {
+        "value": "4rem",
+        "type": "dimension"
+      },
+      "68px|4-25rem": {
+        "value": "4.25rem",
+        "type": "dimension"
+      },
+      "72px|4-5rem": {
+        "value": "4.5rem",
+        "type": "dimension"
+      },
+      "76px|4-75rem": {
+        "value": "4.75rem",
+        "type": "dimension"
+      },
+      "80px|5rem": {
+        "value": "5rem",
+        "type": "dimension"
+      },
+      "84px|5-25rem": {
+        "value": "5.25rem",
+        "type": "dimension"
+      },
+      "88px|5-5rem": {
+        "value": "5.5rem",
+        "type": "dimension"
+      },
+      "92px|5-75rem": {
+        "value": "5.75rem",
+        "type": "dimension"
+      },
+      "96px|6rem": {
+        "value": "6rem",
+        "type": "dimension"
+      },
+      "100px|6-25rem": {
+        "value": "6.25rem",
+        "type": "dimension"
+      },
+      "104px|6-5rem": {
+        "value": "6.5rem",
+        "type": "dimension"
+      },
+      "108px|6-75rem": {
+        "value": "6.75rem",
+        "type": "dimension"
+      },
+      "112px|7rem": {
+        "value": "7rem",
+        "type": "dimension"
+      },
+      "116px|7-25rem": {
+        "value": "7.25rem",
+        "type": "dimension"
+      },
+      "120px|7-5rem": {
+        "value": "7.5rem",
+        "type": "dimension"
+      },
+      "128px|8rem": {
+        "value": "8rem",
+        "type": "dimension"
+      },
+      "14px|0875rem": {
+        "value": "0.875rem",
+        "type": "dimension"
+      },
+      "18px|089rem": {
+        "value": "1.125rem",
+        "type": "dimension"
+      },
+      "6px|0375rem": {
+        "value": "0.375rem",
+        "type": "dimension"
+      },
+      "256px|16rem": {
+        "value": "8rem",
+        "type": "dimension"
+      },
+      "400px|25rem": {
+        "value": "8rem",
+        "type": "dimension"
+      }
+    },
+    "viewport": {
+      "v-w": {
+        "w": {
+          "value": "108rem",
+          "type": "dimension"
+        },
+        "min-w": {
+          "value": "90rem",
+          "type": "dimension"
+        },
+        "max-w": {
+          "value": "120rem",
+          "type": "dimension"
+        }
+      },
+      "v-h": {
+        "h": {
+          "value": "69.8125rem",
+          "type": "dimension"
+        },
+        "min-h": {
+          "value": "48rem",
+          "type": "dimension"
+        },
+        "max-h": {
+          "value": "69.8125rem",
+          "type": "dimension"
+        }
+      }
+    },
+    "gap": {
+      "0": {
+        "value": "0rem",
+        "type": "dimension"
+      },
+      "g-x": {
+        "0": {
+          "value": "0rem",
+          "type": "dimension"
+        },
+        "xs": {
+          "value": "{global.8px|05rem}",
+          "type": "dimension"
+        },
+        "sm": {
+          "value": "{global.16px|1rem}",
+          "type": "dimension"
+        },
+        "md": {
+          "value": "{global.24px|1-5rem}",
+          "type": "dimension"
+        },
+        "lg": {
+          "value": "{global.32px|2rem}",
+          "type": "dimension"
+        },
+        "xl": {
+          "value": "{global.64px|4rem}",
+          "type": "dimension"
+        }
+      },
+      "g-y": {
+        "0": {
+          "value": "0rem",
+          "type": "dimension"
+        },
+        "xs": {
+          "value": "{global.8px|05rem}",
+          "type": "dimension"
+        },
+        "sm": {
+          "value": "{global.16px|1rem}",
+          "type": "dimension"
+        },
+        "md": {
+          "value": "{global.24px|1-5rem}",
+          "type": "dimension"
+        },
+        "lg": {
+          "value": "{global.32px|2rem}",
+          "type": "dimension"
+        },
+        "xl": {
+          "value": "{global.64px|4rem}",
+          "type": "dimension"
+        }
+      }
+    },
+    "padding": {
+      "0": {
+        "value": "0rem",
+        "type": "dimension"
+      },
+      "p-y": {
+        "0": {
+          "value": "0rem",
+          "type": "dimension"
+        },
+        "xs": {
+          "value": "{global.24px|1-5rem}",
+          "type": "dimension"
+        },
+        "sm": {
+          "value": "{global.48px|3rem}",
+          "type": "dimension"
+        },
+        "md": {
+          "value": "{global.64px|4rem}",
+          "type": "dimension"
+        },
+        "lg": {
+          "value": "{global.96px|6rem}",
+          "type": "dimension"
+        },
+        "xl": {
+          "value": "{global.128px|8rem}",
+          "type": "dimension"
+        }
+      },
+      "p-x": {
+        "0": {
+          "value": "0rem",
+          "type": "dimension"
+        },
+        "xs": {
+          "value": "{global.24px|1-5rem}",
+          "type": "dimension"
+        },
+        "sm": {
+          "value": "{global.48px|3rem}",
+          "type": "dimension"
+        },
+        "md": {
+          "value": "{global.64px|4rem}",
+          "type": "dimension"
+        },
+        "lg": {
+          "value": "{global.96px|6rem}",
+          "type": "dimension"
+        },
+        "xl": {
+          "value": "{global.128px|8rem}",
+          "type": "dimension"
+        }
+      }
+    },
+    "text": {
+      "xs": {
+        "value": "{global.12px|075rem}",
+        "type": "dimension"
+      },
+      "sm": {
+        "value": "{global.14px|0875rem}",
+        "type": "dimension"
+      },
+      "base": {
+        "value": "{global.16px|1rem}",
+        "type": "dimension"
+      },
+      "lg": {
+        "value": "{global.20px|1-25rem}",
+        "type": "dimension"
+      },
+      "xl": {
+        "value": "{global.24px|1-5rem}",
+        "type": "dimension"
+      },
+      "2xl": {
+        "value": "{global.32px|2rem}",
+        "type": "dimension"
+      },
+      "3xl": {
+        "value": "{global.40px|2-5rem}",
+        "type": "dimension"
+      },
+      "4xl": {
+        "value": "{global.48px|3rem}",
+        "type": "dimension"
+      },
+      "5xl": {
+        "value": "{global.56px|3-5rem}",
+        "type": "dimension"
+      },
+      "6xl": {
+        "value": "{global.64px|4rem}",
+        "type": "dimension"
+      }
+    },
+    "border-width": {
+      "none": {
+        "value": "{global.0}",
+        "type": "dimension"
+      },
+      "sm": {
+        "value": "{global.4px|025rem}",
+        "type": "dimension"
+      },
+      "base": {
+        "value": "{global.4px|025rem}",
+        "type": "dimension"
+      },
+      "lg": {
+        "value": "{global.8px|05rem}",
+        "type": "dimension"
+      }
+    },
+    "rounded": {
+      "none": {
+        "value": "{global.0}",
+        "type": "dimension"
+      },
+      "sm": {
+        "value": "{global.2px|0125rem}",
+        "type": "dimension"
+      },
+      "2xl": {
+        "value": "{global.16px|1rem}",
+        "type": "dimension"
+      },
+      "3xl": {
+        "value": "{global.24px|1-5rem}",
+        "type": "dimension"
+      },
+      "base": {
+        "value": "{global.4px|025rem}",
+        "type": "dimension"
+      },
+      "md": {
+        "value": "{global.6px|0375rem}",
+        "type": "dimension"
+      },
+      "lg": {
+        "value": "{global.8px|05rem}",
+        "type": "dimension"
+      },
+      "xl": {
+        "value": "{global.12px|075rem}",
+        "type": "dimension"
+      },
+      "full": {
+        "value": "624.9375rem",
+        "type": "dimension"
+      }
+    },
+    "margin": {
+      "m-y": {
+        "0": {
+          "value": "0rem",
+          "type": "dimension"
+        },
+        "xs": {
+          "value": "{global.16px|1rem}",
+          "type": "dimension"
+        },
+        "sm": {
+          "value": "{global.24px|1-5rem}",
+          "type": "dimension"
+        },
+        "md": {
+          "value": "{global.32px|2rem}",
+          "type": "dimension"
+        },
+        "lg": {
+          "value": "{global.48px|3rem}",
+          "type": "dimension"
+        },
+        "xl": {
+          "value": "{global.56px|3-5rem}",
+          "type": "dimension"
+        }
+      },
+      "m-x": {
+        "0": {
+          "value": "0rem",
+          "type": "dimension"
+        },
+        "xs": {
+          "value": "{global.16px|1rem}",
+          "type": "dimension"
+        },
+        "sm": {
+          "value": "{global.24px|1-5rem}",
+          "type": "dimension"
+        },
+        "md": {
+          "value": "{global.32px|2rem}",
+          "type": "dimension"
+        },
+        "lg": {
+          "value": "{global.48px|3rem}",
+          "type": "dimension"
+        },
+        "xl": {
+          "value": "{global.56px|3-5rem}",
+          "type": "dimension"
+        }
+      }
+    }
+  },
+  "num-bi-responsive/mobile-tablet": {
+    "font": {
+      "size": {
+        "headings": {
+          "h1": {
+            "value": "{text.4xl}",
+            "type": "dimension"
+          },
+          "h2": {
+            "value": "{text.3xl}",
+            "type": "dimension"
+          },
+          "h3": {
+            "value": "{text.2xl}",
+            "type": "dimension"
+          },
+          "h4": {
+            "value": "{text.xl}",
+            "type": "dimension"
+          },
+          "h5": {
+            "value": "{text.lg}",
+            "type": "dimension"
+          },
+          "h6": {
+            "value": "{text.base}",
+            "type": "dimension"
+          }
+        },
+        "body": {
+          "lg": {
+            "value": "{text.lg}",
+            "type": "dimension"
+          },
+          "base": {
+            "value": "{text.base}",
+            "type": "dimension"
+          },
+          "sm": {
+            "value": "{text.sm}",
+            "type": "dimension"
+          },
+          "xs": {
+            "value": "{text.xs}",
+            "type": "dimension"
+          },
+          "xl": {
+            "value": "{text.xl}",
+            "type": "dimension"
+          }
+        },
+        "ui": {
+          "sm": {
+            "button": {
+              "value": "{text.sm}",
+              "type": "dimension"
+            },
+            "link": {
+              "value": "{text.sm}",
+              "type": "dimension"
+            },
+            "label": {
+              "value": "{text.sm}",
+              "type": "dimension"
+            },
+            "placeholder": {
+              "value": "{text.sm}",
+              "type": "dimension"
+            },
+            "counter": {
+              "value": "{text.sm}",
+              "type": "dimension"
+            }
+          },
+          "base": {
+            "label": {
+              "value": "{text.base}",
+              "type": "dimension"
+            },
+            "link": {
+              "value": "{text.base}",
+              "type": "dimension"
+            },
+            "button": {
+              "value": "{text.base}",
+              "type": "dimension"
+            },
+            "placeholder": {
+              "value": "{text.base}",
+              "type": "dimension"
+            },
+            "counter": {
+              "value": "{text.base}",
+              "type": "dimension"
+            }
+          },
+          "placeholder": {
+            "value": "{text.sm}",
+            "type": "dimension"
+          },
+          "lg": {
+            "link": {
+              "value": "{text.lg}",
+              "type": "dimension"
+            },
+            "button": {
+              "value": "{text.lg}",
+              "type": "dimension"
+            },
+            "label": {
+              "value": "{text.lg}",
+              "type": "dimension"
+            },
+            "placeholder": {
+              "value": "{text.lg}",
+              "type": "dimension"
+            },
+            "counter": {
+              "value": "{text.lg}",
+              "type": "dimension"
+            }
+          },
+          "tooltip": {
+            "value": "{text.sm}",
+            "type": "dimension"
+          },
+          "navitem": {
+            "value": "{text.base}",
+            "type": "dimension"
+          },
+          "logo": {
+            "value": "{text.xl}",
+            "type": "dimension"
+          },
+          "xl": {
+            "label": {
+              "value": "{text.xl}",
+              "type": "dimension"
+            },
+            "button": {
+              "value": "{text.xl}",
+              "type": "dimension"
+            },
+            "link": {
+              "value": "{text.xl}",
+              "type": "dimension"
+            },
+            "placeholder": {
+              "value": "{text.xl}",
+              "type": "dimension"
+            }
+          },
+          "xs": {
+            "label": {
+              "value": "{text.xs}",
+              "type": "dimension"
+            },
+            "button": {
+              "value": "{text.xs}",
+              "type": "dimension"
+            },
+            "link": {
+              "value": "{text.xs}",
+              "type": "dimension"
+            },
+            "placeholder": {
+              "value": "{text.xs}",
+              "type": "dimension"
+            }
+          }
+        },
+        "display": {
+          "lg": {
+            "value": "{text.6xl}",
+            "type": "dimension"
+          },
+          "sm": {
+            "value": "{text.5xl}",
+            "type": "dimension"
+          }
+        }
+      },
+      "line-height": {
+        "0": {
+          "value": "0rem",
+          "type": "dimension"
+        },
+        "display": {
+          "lg": {
+            "value": "{global.68px|4-25rem}",
+            "type": "dimension"
+          },
+          "sm": {
+            "value": "{global.56px|3-5rem}",
+            "type": "dimension"
+          }
+        },
+        "headings": {
+          "h1": {
+            "value": "{global.60px|3-75rem}",
+            "type": "dimension"
+          },
+          "h2": {
+            "value": "{global.48px|3rem}",
+            "type": "dimension"
+          },
+          "h3": {
+            "value": "{global.36px|2-25rem}",
+            "type": "dimension"
+          },
+          "h4": {
+            "value": "{global.28px|1-75rem}",
+            "type": "dimension"
+          },
+          "h5": {
+            "value": "{global.28px|1-75rem}",
+            "type": "dimension"
+          },
+          "h6": {
+            "value": "{global.24px|1-5rem}",
+            "type": "dimension"
+          }
+        },
+        "body": {
+          "xl": {
+            "value": "{global.36px|2-25rem}",
+            "type": "dimension"
+          },
+          "base": {
+            "value": "{global.24px|1-5rem}",
+            "type": "dimension"
+          },
+          "sm": {
+            "value": "{global.20px|1-25rem}",
+            "type": "dimension"
+          },
+          "xs": {
+            "value": "{global.18px|089rem}",
+            "type": "dimension"
+          },
+          "lg": {
+            "value": "{global.28px|1-75rem}",
+            "type": "dimension"
+          }
+        },
+        "ui": {
+          "sm": {
+            "label": {
+              "value": "{font.line-height.body.sm}",
+              "type": "dimension"
+            },
+            "button": {
+              "value": "{font.line-height.body.sm}",
+              "type": "dimension"
+            },
+            "link": {
+              "value": "{font.line-height.body.sm}",
+              "type": "dimension"
+            },
+            "placeholder": {
+              "value": "{font.line-height.body.sm}",
+              "type": "dimension"
+            },
+            "counter": {
+              "value": "{font.line-height.body.sm}",
+              "type": "dimension"
+            }
+          },
+          "placeholder": {
+            "value": "{font.line-height.body.sm}",
+            "type": "dimension"
+          },
+          "navitem": {
+            "value": "{font.line-height.headings.h6}",
+            "type": "dimension"
+          },
+          "logo": {
+            "value": "{font.line-height.headings.h5}",
+            "type": "dimension"
+          },
+          "base": {
+            "label": {
+              "value": "{font.line-height.body.base}",
+              "type": "dimension"
+            },
+            "button": {
+              "value": "{font.line-height.body.base}",
+              "type": "dimension"
+            },
+            "link": {
+              "value": "{font.line-height.body.base}",
+              "type": "dimension"
+            },
+            "placeholder": {
+              "value": "{font.line-height.body.base}",
+              "type": "dimension"
+            },
+            "counter": {
+              "value": "{font.line-height.body.base}",
+              "type": "dimension"
+            }
+          },
+          "lg": {
+            "label": {
+              "value": "{font.line-height.body.lg}",
+              "type": "dimension"
+            },
+            "button": {
+              "value": "{font.line-height.body.lg}",
+              "type": "dimension"
+            },
+            "link": {
+              "value": "{font.line-height.body.lg}",
+              "type": "dimension"
+            },
+            "placeholder": {
+              "value": "{font.line-height.body.lg}",
+              "type": "dimension"
+            },
+            "counter": {
+              "value": "{font.line-height.body.lg}",
+              "type": "dimension"
+            }
+          },
+          "tooltip": {
+            "value": "{font.line-height.body.sm}",
+            "type": "dimension"
+          },
+          "xs": {
+            "label": {
+              "value": "{font.line-height.body.xs}",
+              "type": "dimension"
+            },
+            "button": {
+              "value": "{font.line-height.body.xs}",
+              "type": "dimension"
+            },
+            "link": {
+              "value": "{font.line-height.body.xs}",
+              "type": "dimension"
+            },
+            "placeholder": {
+              "value": "{font.line-height.body.xs}",
+              "type": "dimension"
+            }
+          },
+          "xl": {
+            "label": {
+              "value": "{font.line-height.body.xl}",
+              "type": "dimension"
+            },
+            "button": {
+              "value": "{font.line-height.body.xl}",
+              "type": "dimension"
+            },
+            "link": {
+              "value": "{font.line-height.body.xl}",
+              "type": "dimension"
+            },
+            "placeholder": {
+              "value": "{font.line-height.body.xl}",
+              "type": "dimension"
+            }
+          }
+        }
+      },
+      "letter-spacing": {
+        "0": {
+          "value": "0rem",
+          "type": "dimension"
+        },
+        "heading": {
+          "value": "0rem",
+          "type": "dimension"
+        },
+        "body": {
+          "value": "0rem",
+          "type": "dimension",
+          "body": {
+            "value": "{font.letter-spacing.0}",
+            "type": "dimension"
+          }
+        },
+        "display": {
+          "lg": {
+            "value": "0.14000000059604645rem",
+            "type": "dimension"
+          },
+          "sm": {
+            "value": "0.11999999731779099rem",
+            "type": "dimension"
+          }
+        },
+        "headings": {
+          "h1": {
+            "value": "0.10000000149011612rem",
+            "type": "dimension"
+          },
+          "h2": {
+            "value": "0.07999999821186066rem",
+            "type": "dimension"
+          },
+          "h3": {
+            "value": "0.05999999865889549rem",
+            "type": "dimension"
+          },
+          "h4": {
+            "value": "0.05000000074505806rem",
+            "type": "dimension"
+          },
+          "h5": {
+            "value": "0.04500000178813934rem",
+            "type": "dimension"
+          },
+          "h6": {
+            "value": "0.03999999910593033rem",
+            "type": "dimension"
+          }
+        }
+      }
+    }
+  },
+  "num-bi-responsive/laptop-desktop": {
+    "font": {
+      "size": {
+        "headings": {
+          "h1": {
+            "value": "{text.4xl}",
+            "type": "dimension"
+          },
+          "h2": {
+            "value": "{text.3xl}",
+            "type": "dimension"
+          },
+          "h3": {
+            "value": "{text.2xl}",
+            "type": "dimension"
+          },
+          "h4": {
+            "value": "{text.xl}",
+            "type": "dimension"
+          },
+          "h5": {
+            "value": "{text.lg}",
+            "type": "dimension"
+          },
+          "h6": {
+            "value": "{text.base}",
+            "type": "dimension"
+          }
+        },
+        "body": {
+          "lg": {
+            "value": "{text.lg}",
+            "type": "dimension"
+          },
+          "base": {
+            "value": "{text.base}",
+            "type": "dimension"
+          },
+          "sm": {
+            "value": "{text.sm}",
+            "type": "dimension"
+          },
+          "xs": {
+            "value": "{text.xs}",
+            "type": "dimension"
+          },
+          "xl": {
+            "value": "{text.xl}",
+            "type": "dimension"
+          }
+        },
+        "ui": {
+          "sm": {
+            "button": {
+              "value": "{text.sm}",
+              "type": "dimension"
+            },
+            "link": {
+              "value": "{text.sm}",
+              "type": "dimension"
+            },
+            "label": {
+              "value": "{text.sm}",
+              "type": "dimension"
+            },
+            "placeholder": {
+              "value": "{text.sm}",
+              "type": "dimension"
+            },
+            "counter": {
+              "value": "{text.sm}",
+              "type": "dimension"
+            }
+          },
+          "base": {
+            "label": {
+              "value": "{text.base}",
+              "type": "dimension"
+            },
+            "link": {
+              "value": "{text.base}",
+              "type": "dimension"
+            },
+            "button": {
+              "value": "{text.base}",
+              "type": "dimension"
+            },
+            "placeholder": {
+              "value": "{text.base}",
+              "type": "dimension"
+            },
+            "counter": {
+              "value": "{text.base}",
+              "type": "dimension"
+            }
+          },
+          "placeholder": {
+            "value": "{text.sm}",
+            "type": "dimension"
+          },
+          "lg": {
+            "link": {
+              "value": "{text.lg}",
+              "type": "dimension"
+            },
+            "button": {
+              "value": "{text.lg}",
+              "type": "dimension"
+            },
+            "label": {
+              "value": "{text.lg}",
+              "type": "dimension"
+            },
+            "placeholder": {
+              "value": "{text.lg}",
+              "type": "dimension"
+            },
+            "counter": {
+              "value": "{text.lg}",
+              "type": "dimension"
+            }
+          },
+          "tooltip": {
+            "value": "{text.sm}",
+            "type": "dimension"
+          },
+          "navitem": {
+            "value": "{text.base}",
+            "type": "dimension"
+          },
+          "logo": {
+            "value": "{text.xl}",
+            "type": "dimension"
+          },
+          "xl": {
+            "label": {
+              "value": "{text.xl}",
+              "type": "dimension"
+            },
+            "button": {
+              "value": "{text.xl}",
+              "type": "dimension"
+            },
+            "link": {
+              "value": "{text.xl}",
+              "type": "dimension"
+            },
+            "placeholder": {
+              "value": "{text.xl}",
+              "type": "dimension"
+            }
+          },
+          "xs": {
+            "label": {
+              "value": "{text.xs}",
+              "type": "dimension"
+            },
+            "button": {
+              "value": "{text.xs}",
+              "type": "dimension"
+            },
+            "link": {
+              "value": "{text.xs}",
+              "type": "dimension"
+            },
+            "placeholder": {
+              "value": "{text.xs}",
+              "type": "dimension"
+            }
+          }
+        },
+        "display": {
+          "lg": {
+            "value": "{text.6xl}",
+            "type": "dimension"
+          },
+          "sm": {
+            "value": "{text.5xl}",
+            "type": "dimension"
+          }
+        }
+      },
+      "line-height": {
+        "0": {
+          "value": "0rem",
+          "type": "dimension"
+        },
+        "display": {
+          "lg": {
+            "value": "{global.76px|4-75rem}",
+            "type": "dimension"
+          },
+          "sm": {
+            "value": "{global.68px|4-25rem}",
+            "type": "dimension"
+          }
+        },
+        "headings": {
+          "h1": {
+            "value": "{global.56px|3-5rem}",
+            "type": "dimension"
+          },
+          "h2": {
+            "value": "{global.48px|3rem}",
+            "type": "dimension"
+          },
+          "h3": {
+            "value": "{global.40px|2-5rem}",
+            "type": "dimension"
+          },
+          "h4": {
+            "value": "{global.28px|1-75rem}",
+            "type": "dimension"
+          },
+          "h5": {
+            "value": "{global.24px|1-5rem}",
+            "type": "dimension"
+          },
+          "h6": {
+            "value": "{global.24px|1-5rem}",
+            "type": "dimension"
+          }
+        },
+        "body": {
+          "xl": {
+            "value": "{global.48px|3rem}",
+            "type": "dimension"
+          },
+          "base": {
+            "value": "{global.24px|1-5rem}",
+            "type": "dimension"
+          },
+          "sm": {
+            "value": "{global.20px|1-25rem}",
+            "type": "dimension"
+          },
+          "xs": {
+            "value": "{global.18px|089rem}",
+            "type": "dimension"
+          },
+          "lg": {
+            "value": "{global.28px|1-75rem}",
+            "type": "dimension"
+          }
+        },
+        "ui": {
+          "sm": {
+            "label": {
+              "value": "{font.line-height.body.sm}",
+              "type": "dimension"
+            },
+            "button": {
+              "value": "{font.line-height.body.sm}",
+              "type": "dimension"
+            },
+            "link": {
+              "value": "{font.line-height.body.sm}",
+              "type": "dimension"
+            },
+            "placeholder": {
+              "value": "{font.line-height.body.sm}",
+              "type": "dimension"
+            },
+            "counter": {
+              "value": "{font.line-height.body.sm}",
+              "type": "dimension"
+            }
+          },
+          "placeholder": {
+            "value": "{font.line-height.body.sm}",
+            "type": "dimension"
+          },
+          "navitem": {
+            "value": "{font.line-height.headings.h6}",
+            "type": "dimension"
+          },
+          "logo": {
+            "value": "{font.line-height.headings.h5}",
+            "type": "dimension"
+          },
+          "base": {
+            "label": {
+              "value": "{font.line-height.body.base}",
+              "type": "dimension"
+            },
+            "button": {
+              "value": "{font.line-height.body.base}",
+              "type": "dimension"
+            },
+            "link": {
+              "value": "{font.line-height.body.base}",
+              "type": "dimension"
+            },
+            "placeholder": {
+              "value": "{font.line-height.body.base}",
+              "type": "dimension"
+            },
+            "counter": {
+              "value": "{font.line-height.body.base}",
+              "type": "dimension"
+            }
+          },
+          "lg": {
+            "label": {
+              "value": "{font.line-height.body.lg}",
+              "type": "dimension"
+            },
+            "button": {
+              "value": "{font.line-height.body.lg}",
+              "type": "dimension"
+            },
+            "link": {
+              "value": "{font.line-height.body.lg}",
+              "type": "dimension"
+            },
+            "placeholder": {
+              "value": "{font.line-height.body.lg}",
+              "type": "dimension"
+            },
+            "counter": {
+              "value": "{font.line-height.body.lg}",
+              "type": "dimension"
+            }
+          },
+          "tooltip": {
+            "value": "{font.line-height.body.sm}",
+            "type": "dimension"
+          },
+          "xs": {
+            "label": {
+              "value": "{font.line-height.body.xs}",
+              "type": "dimension"
+            },
+            "button": {
+              "value": "{font.line-height.body.xs}",
+              "type": "dimension"
+            },
+            "link": {
+              "value": "{font.line-height.body.xs}",
+              "type": "dimension"
+            },
+            "placeholder": {
+              "value": "{font.line-height.body.xs}",
+              "type": "dimension"
+            }
+          },
+          "xl": {
+            "label": {
+              "value": "{font.line-height.body.xl}",
+              "type": "dimension"
+            },
+            "button": {
+              "value": "{font.line-height.body.xl}",
+              "type": "dimension"
+            },
+            "link": {
+              "value": "{font.line-height.body.xl}",
+              "type": "dimension"
+            },
+            "placeholder": {
+              "value": "{font.line-height.body.xl}",
+              "type": "dimension"
+            }
+          }
+        }
+      },
+      "letter-spacing": {
+        "0": {
+          "value": "0rem",
+          "type": "dimension"
+        },
+        "heading": {
+          "value": "0rem",
+          "type": "dimension"
+        },
+        "body": {
+          "value": "0rem",
+          "type": "dimension",
+          "body": {
+            "value": "{font.letter-spacing.0}",
+            "type": "dimension"
+          }
+        },
+        "display": {
+          "lg": {
+            "value": "0.1599999964237213rem",
+            "type": "dimension"
+          },
+          "sm": {
+            "value": "0.14000000059604645rem",
+            "type": "dimension"
+          }
+        },
+        "headings": {
+          "h1": {
+            "value": "0.11999999731779099rem",
+            "type": "dimension"
+          },
+          "h2": {
+            "value": "0.10000000149011612rem",
+            "type": "dimension"
+          },
+          "h3": {
+            "value": "0.07999999821186066rem",
+            "type": "dimension"
+          },
+          "h4": {
+            "value": "0.05999999865889549rem",
+            "type": "dimension"
+          },
+          "h5": {
+            "value": "0.05000000074505806rem",
+            "type": "dimension"
+          },
+          "h6": {
+            "value": "0.03999999910593033rem",
+            "type": "dimension"
+          }
+        }
+      }
+    }
+  },
+  "num-bi-responsive/static": {
+    "font": {
+      "size": {
+        "headings": {
+          "h1": {
+            "value": "{text.4xl}",
+            "type": "dimension"
+          },
+          "h2": {
+            "value": "{text.3xl}",
+            "type": "dimension"
+          },
+          "h3": {
+            "value": "{text.2xl}",
+            "type": "dimension"
+          },
+          "h4": {
+            "value": "{text.xl}",
+            "type": "dimension"
+          },
+          "h5": {
+            "value": "{text.lg}",
+            "type": "dimension"
+          },
+          "h6": {
+            "value": "{text.base}",
+            "type": "dimension"
+          }
+        },
+        "body": {
+          "lg": {
+            "value": "{text.lg}",
+            "type": "dimension"
+          },
+          "base": {
+            "value": "{text.base}",
+            "type": "dimension"
+          },
+          "sm": {
+            "value": "{text.sm}",
+            "type": "dimension"
+          },
+          "xs": {
+            "value": "{text.xs}",
+            "type": "dimension"
+          },
+          "xl": {
+            "value": "{text.xl}",
+            "type": "dimension"
+          }
+        },
+        "ui": {
+          "sm": {
+            "button": {
+              "value": "{text.sm}",
+              "type": "dimension"
+            },
+            "link": {
+              "value": "{text.sm}",
+              "type": "dimension"
+            },
+            "label": {
+              "value": "{text.sm}",
+              "type": "dimension"
+            },
+            "placeholder": {
+              "value": "{text.sm}",
+              "type": "dimension"
+            },
+            "counter": {
+              "value": "{text.sm}",
+              "type": "dimension"
+            }
+          },
+          "base": {
+            "label": {
+              "value": "{text.base}",
+              "type": "dimension"
+            },
+            "link": {
+              "value": "{text.base}",
+              "type": "dimension"
+            },
+            "button": {
+              "value": "{text.base}",
+              "type": "dimension"
+            },
+            "placeholder": {
+              "value": "{text.base}",
+              "type": "dimension"
+            },
+            "counter": {
+              "value": "{text.base}",
+              "type": "dimension"
+            }
+          },
+          "placeholder": {
+            "value": "{text.sm}",
+            "type": "dimension"
+          },
+          "lg": {
+            "link": {
+              "value": "{text.lg}",
+              "type": "dimension"
+            },
+            "button": {
+              "value": "{text.lg}",
+              "type": "dimension"
+            },
+            "label": {
+              "value": "{text.lg}",
+              "type": "dimension"
+            },
+            "placeholder": {
+              "value": "{text.lg}",
+              "type": "dimension"
+            },
+            "counter": {
+              "value": "{text.lg}",
+              "type": "dimension"
+            }
+          },
+          "tooltip": {
+            "value": "{text.sm}",
+            "type": "dimension"
+          },
+          "navitem": {
+            "value": "{text.base}",
+            "type": "dimension"
+          },
+          "logo": {
+            "value": "{text.xl}",
+            "type": "dimension"
+          },
+          "xl": {
+            "label": {
+              "value": "{text.xl}",
+              "type": "dimension"
+            },
+            "button": {
+              "value": "{text.xl}",
+              "type": "dimension"
+            },
+            "link": {
+              "value": "{text.xl}",
+              "type": "dimension"
+            },
+            "placeholder": {
+              "value": "{text.xl}",
+              "type": "dimension"
+            }
+          },
+          "xs": {
+            "label": {
+              "value": "{text.xs}",
+              "type": "dimension"
+            },
+            "button": {
+              "value": "{text.xs}",
+              "type": "dimension"
+            },
+            "link": {
+              "value": "{text.xs}",
+              "type": "dimension"
+            },
+            "placeholder": {
+              "value": "{text.xs}",
+              "type": "dimension"
+            }
+          }
+        },
+        "display": {
+          "lg": {
+            "value": "{text.6xl}",
+            "type": "dimension"
+          },
+          "sm": {
+            "value": "{text.5xl}",
+            "type": "dimension"
+          }
+        }
+      },
+      "line-height": {
+        "0": {
+          "value": "0rem",
+          "type": "dimension"
+        },
+        "display": {
+          "lg": {
+            "value": "{global.76px|4-75rem}",
+            "type": "dimension"
+          },
+          "sm": {
+            "value": "{global.68px|4-25rem}",
+            "type": "dimension"
+          }
+        },
+        "headings": {
+          "h1": {
+            "value": "{global.56px|3-5rem}",
+            "type": "dimension"
+          },
+          "h2": {
+            "value": "{global.48px|3rem}",
+            "type": "dimension"
+          },
+          "h3": {
+            "value": "{global.40px|2-5rem}",
+            "type": "dimension"
+          },
+          "h4": {
+            "value": "{global.28px|1-75rem}",
+            "type": "dimension"
+          },
+          "h5": {
+            "value": "{global.24px|1-5rem}",
+            "type": "dimension"
+          },
+          "h6": {
+            "value": "{global.24px|1-5rem}",
+            "type": "dimension"
+          }
+        },
+        "body": {
+          "xl": {
+            "value": "{global.48px|3rem}",
+            "type": "dimension"
+          },
+          "base": {
+            "value": "{global.24px|1-5rem}",
+            "type": "dimension"
+          },
+          "sm": {
+            "value": "{global.20px|1-25rem}",
+            "type": "dimension"
+          },
+          "xs": {
+            "value": "{global.18px|089rem}",
+            "type": "dimension"
+          },
+          "lg": {
+            "value": "{global.28px|1-75rem}",
+            "type": "dimension"
+          }
+        },
+        "ui": {
+          "sm": {
+            "label": {
+              "value": "{font.line-height.body.sm}",
+              "type": "dimension"
+            },
+            "button": {
+              "value": "{font.line-height.body.sm}",
+              "type": "dimension"
+            },
+            "link": {
+              "value": "{font.line-height.body.sm}",
+              "type": "dimension"
+            },
+            "placeholder": {
+              "value": "{font.line-height.body.sm}",
+              "type": "dimension"
+            },
+            "counter": {
+              "value": "{font.line-height.body.sm}",
+              "type": "dimension"
+            }
+          },
+          "placeholder": {
+            "value": "{font.line-height.body.sm}",
+            "type": "dimension"
+          },
+          "navitem": {
+            "value": "{font.line-height.headings.h6}",
+            "type": "dimension"
+          },
+          "logo": {
+            "value": "{font.line-height.headings.h5}",
+            "type": "dimension"
+          },
+          "base": {
+            "label": {
+              "value": "{font.line-height.body.base}",
+              "type": "dimension"
+            },
+            "button": {
+              "value": "{font.line-height.body.base}",
+              "type": "dimension"
+            },
+            "link": {
+              "value": "{font.line-height.body.base}",
+              "type": "dimension"
+            },
+            "placeholder": {
+              "value": "{font.line-height.body.base}",
+              "type": "dimension"
+            },
+            "counter": {
+              "value": "{font.line-height.body.base}",
+              "type": "dimension"
+            }
+          },
+          "lg": {
+            "label": {
+              "value": "{font.line-height.body.lg}",
+              "type": "dimension"
+            },
+            "button": {
+              "value": "{font.line-height.body.lg}",
+              "type": "dimension"
+            },
+            "link": {
+              "value": "{font.line-height.body.lg}",
+              "type": "dimension"
+            },
+            "placeholder": {
+              "value": "{font.line-height.body.lg}",
+              "type": "dimension"
+            },
+            "counter": {
+              "value": "{font.line-height.body.lg}",
+              "type": "dimension"
+            }
+          },
+          "tooltip": {
+            "value": "{font.line-height.body.sm}",
+            "type": "dimension"
+          },
+          "xs": {
+            "label": {
+              "value": "{font.line-height.body.xs}",
+              "type": "dimension"
+            },
+            "button": {
+              "value": "{font.line-height.body.xs}",
+              "type": "dimension"
+            },
+            "link": {
+              "value": "{font.line-height.body.xs}",
+              "type": "dimension"
+            },
+            "placeholder": {
+              "value": "{font.line-height.body.xs}",
+              "type": "dimension"
+            }
+          },
+          "xl": {
+            "label": {
+              "value": "{font.line-height.body.xl}",
+              "type": "dimension"
+            },
+            "button": {
+              "value": "{font.line-height.body.xl}",
+              "type": "dimension"
+            },
+            "link": {
+              "value": "{font.line-height.body.xl}",
+              "type": "dimension"
+            },
+            "placeholder": {
+              "value": "{font.line-height.body.xl}",
+              "type": "dimension"
+            }
+          }
+        }
+      },
+      "letter-spacing": {
+        "0": {
+          "value": "0rem",
+          "type": "dimension"
+        },
+        "heading": {
+          "value": "0rem",
+          "type": "dimension"
+        },
+        "body": {
+          "value": "0rem",
+          "type": "dimension",
+          "body": {
+            "value": "{font.letter-spacing.0}",
+            "type": "dimension"
+          }
+        },
+        "display": {
+          "lg": {
+            "value": "0.1599999964237213rem",
+            "type": "dimension"
+          },
+          "sm": {
+            "value": "0.14000000059604645rem",
+            "type": "dimension"
+          }
+        },
+        "headings": {
+          "h1": {
+            "value": "0.11999999731779099rem",
+            "type": "dimension"
+          },
+          "h2": {
+            "value": "0.10000000149011612rem",
+            "type": "dimension"
+          },
+          "h3": {
+            "value": "0.07999999821186066rem",
+            "type": "dimension"
+          },
+          "h4": {
+            "value": "0.05999999865889549rem",
+            "type": "dimension"
+          },
+          "h5": {
+            "value": "0.05000000074505806rem",
+            "type": "dimension"
+          },
+          "h6": {
+            "value": "0.03999999910593033rem",
+            "type": "dimension"
+          }
+        }
+      }
+    }
+  },
+  "num-static/static": {
+    "global": {
+      "0": {
+        "value": "0rem",
+        "type": "dimension"
+      },
+      "2px|0125rem": {
+        "value": "0.125rem",
+        "type": "dimension"
+      },
+      "4px|025rem": {
+        "value": "0.25rem",
+        "type": "dimension"
+      },
+      "8px|05rem": {
+        "value": "0.5rem",
+        "type": "dimension"
+      },
+      "12px|075rem": {
+        "value": "0.75rem",
+        "type": "dimension"
+      },
+      "16px|1rem": {
+        "value": "1rem",
+        "type": "dimension"
+      },
+      "20px|1-25rem": {
+        "value": "1.25rem",
+        "type": "dimension"
+      },
+      "24px|1-5rem": {
+        "value": "1.5rem",
+        "type": "dimension"
+      },
+      "28px|1-75rem": {
+        "value": "1.75rem",
+        "type": "dimension"
+      },
+      "32px|2rem": {
+        "value": "2rem",
+        "type": "dimension"
+      },
+      "36px|2-25rem": {
+        "value": "2.25rem",
+        "type": "dimension"
+      },
+      "40px|2-5rem": {
+        "value": "2.5rem",
+        "type": "dimension"
+      },
+      "44px|2-75rem": {
+        "value": "2.75rem",
+        "type": "dimension"
+      },
+      "48px|3rem": {
+        "value": "3rem",
+        "type": "dimension"
+      },
+      "52px|3-25rem": {
+        "value": "3.25rem",
+        "type": "dimension"
+      },
+      "56px|3-5rem": {
+        "value": "3.5rem",
+        "type": "dimension"
+      },
+      "60px|3-75rem": {
+        "value": "3.75rem",
+        "type": "dimension"
+      },
+      "64px|4rem": {
+        "value": "4rem",
+        "type": "dimension"
+      },
+      "68px|4-25rem": {
+        "value": "4.25rem",
+        "type": "dimension"
+      },
+      "72px|4-5rem": {
+        "value": "4.5rem",
+        "type": "dimension"
+      },
+      "76px|4-75rem": {
+        "value": "4.75rem",
+        "type": "dimension"
+      },
+      "80px|5rem": {
+        "value": "5rem",
+        "type": "dimension"
+      },
+      "84px|5-25rem": {
+        "value": "5.25rem",
+        "type": "dimension"
+      },
+      "88px|5-5rem": {
+        "value": "5.5rem",
+        "type": "dimension"
+      },
+      "92px|5-75rem": {
+        "value": "5.75rem",
+        "type": "dimension"
+      },
+      "96px|6rem": {
+        "value": "6rem",
+        "type": "dimension"
+      },
+      "100px|6-25rem": {
+        "value": "6.25rem",
+        "type": "dimension"
+      },
+      "104px|6-5rem": {
+        "value": "6.5rem",
+        "type": "dimension"
+      },
+      "108px|6-75rem": {
+        "value": "6.75rem",
+        "type": "dimension"
+      },
+      "112px|7rem": {
+        "value": "7rem",
+        "type": "dimension"
+      },
+      "116px|7-25rem": {
+        "value": "7.25rem",
+        "type": "dimension"
+      },
+      "120px|7-5rem": {
+        "value": "7.5rem",
+        "type": "dimension"
+      },
+      "128px|8rem": {
+        "value": "8rem",
+        "type": "dimension"
+      },
+      "14px|0875rem": {
+        "value": "0.875rem",
+        "type": "dimension"
+      },
+      "18px|089rem": {
+        "value": "1.125rem",
+        "type": "dimension"
+      },
+      "6px|0375rem": {
+        "value": "0.375rem",
+        "type": "dimension"
+      },
+      "256px|16rem": {
+        "value": "16rem",
+        "type": "dimension"
+      },
+      "400px|25rem": {
+        "value": "25rem",
+        "type": "dimension"
+      }
+    },
+    "gap": {
+      "0": {
+        "value": "0rem",
+        "type": "dimension"
+      },
+      "g": {
+        "0": {
+          "value": "{global.0}",
+          "type": "dimension"
+        },
+        "xxs": {
+          "value": "{global.2px|0125rem}",
+          "type": "dimension"
+        },
+        "sm": {
+          "value": "{global.6px|0375rem}",
+          "type": "dimension"
+        },
+        "md": {
+          "value": "{global.8px|05rem}",
+          "type": "dimension"
+        },
+        "lg": {
+          "value": "{global.12px|075rem}",
+          "type": "dimension"
+        },
+        "xl": {
+          "value": "{global.16px|1rem}",
+          "type": "dimension"
+        },
+        "xs": {
+          "value": "{global.4px|025rem}",
+          "type": "dimension"
+        },
+        "xxxl": {
+          "value": "{global.24px|1-5rem}",
+          "type": "dimension"
+        },
+        "xxl": {
+          "value": "{global.18px|089rem}",
+          "type": "dimension"
+        }
+      }
+    },
+    "padding": {
+      "0": {
+        "value": "0rem",
+        "type": "dimension"
+      },
+      "p": {
+        "0": {
+          "value": "{global.0}",
+          "type": "dimension"
+        },
+        "xxs": {
+          "value": "{global.2px|0125rem}",
+          "type": "dimension"
+        },
+        "sm": {
+          "value": "{global.6px|0375rem}",
+          "type": "dimension"
+        },
+        "md": {
+          "value": "{global.8px|05rem}",
+          "type": "dimension"
+        },
+        "lg": {
+          "value": "{global.12px|075rem}",
+          "type": "dimension"
+        },
+        "xl": {
+          "value": "{global.16px|1rem}",
+          "type": "dimension"
+        },
+        "xs": {
+          "value": "{global.4px|025rem}",
+          "type": "dimension"
+        },
+        "xxxl": {
+          "value": "{global.24px|1-5rem}",
+          "type": "dimension"
+        },
+        "xxl": {
+          "value": "{global.18px|089rem}",
+          "type": "dimension"
+        }
+      }
+    },
+    "text": {
+      "xs": {
+        "value": "{global.12px|075rem}",
+        "type": "dimension"
+      },
+      "sm": {
+        "value": "{global.14px|0875rem}",
+        "type": "dimension"
+      },
+      "base": {
+        "value": "{global.16px|1rem}",
+        "type": "dimension"
+      },
+      "lg": {
+        "value": "{global.18px|089rem}",
+        "type": "dimension"
+      },
+      "xl": {
+        "value": "{global.20px|1-25rem}",
+        "type": "dimension"
+      },
+      "2xl": {
+        "value": "{global.24px|1-5rem}",
+        "type": "dimension"
+      },
+      "3xl": {
+        "value": "{global.32px|2rem}",
+        "type": "dimension"
+      },
+      "4xl": {
+        "value": "{global.40px|2-5rem}",
+        "type": "dimension"
+      },
+      "5xl": {
+        "value": "{global.48px|3rem}",
+        "type": "dimension"
+      },
+      "6xl": {
+        "value": "{global.56px|3-5rem}",
+        "type": "dimension"
+      }
+    },
+    "border-width": {
+      "none": {
+        "value": "{global.0}",
+        "type": "dimension"
+      },
+      "sm": {
+        "value": "{global.2px|0125rem}",
+        "type": "dimension"
+      },
+      "base": {
+        "value": "{global.4px|025rem}",
+        "type": "dimension"
+      },
+      "lg": {
+        "value": "{global.4px|025rem}",
+        "type": "dimension"
+      }
+    },
+    "rounded": {
+      "none": {
+        "value": "{global.0}",
+        "type": "dimension"
+      },
+      "sm": {
+        "value": "{global.2px|0125rem}",
+        "type": "dimension"
+      },
+      "2xl": {
+        "value": "{global.16px|1rem}",
+        "type": "dimension"
+      },
+      "3xl": {
+        "value": "{global.24px|1-5rem}",
+        "type": "dimension"
+      },
+      "base": {
+        "value": "{global.4px|025rem}",
+        "type": "dimension"
+      },
+      "md": {
+        "value": "{global.6px|0375rem}",
+        "type": "dimension"
+      },
+      "lg": {
+        "value": "{global.8px|05rem}",
+        "type": "dimension"
+      },
+      "xl": {
+        "value": "{global.12px|075rem}",
+        "type": "dimension"
+      },
+      "full": {
+        "value": "624.9375rem",
+        "type": "dimension"
+      }
+    },
+    "effect": {
+      "outer-shadow": {
+        "sm": {
+          "x": {
+            "value": "0rem",
+            "type": "dimension"
+          },
+          "y": {
+            "value": "0.0625rem",
+            "type": "dimension"
+          },
+          "blur": {
+            "value": "0.125rem",
+            "type": "dimension"
+          },
+          "spread": {
+            "value": "0rem",
+            "type": "dimension"
+          }
+        },
+        "base": {
+          "02": {
+            "x": {
+              "value": "0rem",
+              "type": "dimension"
+            },
+            "y": {
+              "value": "0.0625rem",
+              "type": "dimension"
+            },
+            "blur": {
+              "value": "0.1875rem",
+              "type": "dimension"
+            },
+            "spread": {
+              "value": "0rem",
+              "type": "dimension"
+            }
+          },
+          "01": {
+            "x": {
+              "value": "0rem",
+              "type": "dimension"
+            },
+            "y": {
+              "value": "0.0625rem",
+              "type": "dimension"
+            },
+            "blur": {
+              "value": "0.125rem",
+              "type": "dimension"
+            },
+            "spread": {
+              "value": "0rem",
+              "type": "dimension"
+            }
+          }
+        },
+        "md": {
+          "01": {
+            "x": {
+              "value": "0rem",
+              "type": "dimension"
+            },
+            "y": {
+              "value": "0.25rem",
+              "type": "dimension"
+            },
+            "blur": {
+              "value": "0.375rem",
+              "type": "dimension"
+            },
+            "spread": {
+              "value": "-0.0625rem",
+              "type": "dimension"
+            }
+          },
+          "02": {
+            "x": {
+              "value": "0rem",
+              "type": "dimension"
+            },
+            "y": {
+              "value": "0.125rem",
+              "type": "dimension"
+            },
+            "blur": {
+              "value": "0.25rem",
+              "type": "dimension"
+            },
+            "spread": {
+              "value": "-0.125rem",
+              "type": "dimension"
+            }
+          }
+        },
+        "lg": {
+          "01": {
+            "x": {
+              "value": "0rem",
+              "type": "dimension"
+            },
+            "y": {
+              "value": "0.625rem",
+              "type": "dimension"
+            },
+            "blur": {
+              "value": "0.9375rem",
+              "type": "dimension"
+            },
+            "spread": {
+              "value": "-0.1875rem",
+              "type": "dimension"
+            }
+          },
+          "02": {
+            "x": {
+              "value": "0rem",
+              "type": "dimension"
+            },
+            "y": {
+              "value": "0.25rem",
+              "type": "dimension"
+            },
+            "blur": {
+              "value": "0.375rem",
+              "type": "dimension"
+            },
+            "spread": {
+              "value": "-0.25rem",
+              "type": "dimension"
+            }
+          }
+        },
+        "xl": {
+          "01": {
+            "x": {
+              "value": "0rem",
+              "type": "dimension"
+            },
+            "y": {
+              "value": "1.25rem",
+              "type": "dimension"
+            },
+            "blur": {
+              "value": "1.5625rem",
+              "type": "dimension"
+            },
+            "spread": {
+              "value": "-0.3125rem",
+              "type": "dimension"
+            }
+          },
+          "02": {
+            "x": {
+              "value": "0rem",
+              "type": "dimension"
+            },
+            "y": {
+              "value": "0.5rem",
+              "type": "dimension"
+            },
+            "blur": {
+              "value": "0.625rem",
+              "type": "dimension"
+            },
+            "spread": {
+              "value": "-0.375rem",
+              "type": "dimension"
+            }
+          }
+        },
+        "2xl": {
+          "x": {
+            "value": "0rem",
+            "type": "dimension"
+          },
+          "y": {
+            "value": "1.5625rem",
+            "type": "dimension"
+          },
+          "blur": {
+            "value": "3.125rem",
+            "type": "dimension"
+          },
+          "spread": {
+            "value": "-0.75rem",
+            "type": "dimension"
+          }
+        }
+      },
+      "inner-shadow": {
+        "sm": {
+          "x": {
+            "value": "0.125rem",
+            "type": "dimension"
+          },
+          "y": {
+            "value": "0.125rem",
+            "type": "dimension"
+          },
+          "blur": {
+            "value": "0.375rem",
+            "type": "dimension"
+          },
+          "spread": {
+            "value": "0rem",
+            "type": "dimension"
+          }
+        },
+        "base": {
+          "01": {
+            "x": {
+              "value": "0.125rem",
+              "type": "dimension"
+            },
+            "y": {
+              "value": "0.125rem",
+              "type": "dimension"
+            },
+            "blur": {
+              "value": "0.5rem",
+              "type": "dimension"
+            },
+            "spread": {
+              "value": "0rem",
+              "type": "dimension"
+            }
+          },
+          "*02": {
+            "x": {
+              "value": "0rem",
+              "type": "dimension"
+            },
+            "y": {
+              "value": "0.0625rem",
+              "type": "dimension"
+            },
+            "blur": {
+              "value": "0.1875rem",
+              "type": "dimension"
+            },
+            "spread": {
+              "value": "0rem",
+              "type": "dimension"
+            }
+          }
+        },
+        "md": {
+          "01": {
+            "x": {
+              "value": "0.125rem",
+              "type": "dimension"
+            },
+            "y": {
+              "value": "0.125rem",
+              "type": "dimension"
+            },
+            "blur": {
+              "value": "0.5rem",
+              "type": "dimension"
+            },
+            "spread": {
+              "value": "0rem",
+              "type": "dimension"
+            }
+          },
+          "*02": {
+            "x": {
+              "value": "0rem",
+              "type": "dimension"
+            },
+            "y": {
+              "value": "0.125rem",
+              "type": "dimension"
+            },
+            "blur": {
+              "value": "0.25rem",
+              "type": "dimension"
+            },
+            "spread": {
+              "value": "-0.125rem",
+              "type": "dimension"
+            }
+          }
+        },
+        "lg": {
+          "01": {
+            "x": {
+              "value": "0rem",
+              "type": "dimension"
+            },
+            "y": {
+              "value": "0.625rem",
+              "type": "dimension"
+            },
+            "blur": {
+              "value": "0.9375rem",
+              "type": "dimension"
+            },
+            "spread": {
+              "value": "-0.1875rem",
+              "type": "dimension"
+            }
+          },
+          "*02": {
+            "x": {
+              "value": "0.125rem",
+              "type": "dimension"
+            },
+            "y": {
+              "value": "0.125rem",
+              "type": "dimension"
+            },
+            "blur": {
+              "value": "0.5rem",
+              "type": "dimension"
+            },
+            "spread": {
+              "value": "0rem",
+              "type": "dimension"
+            }
+          }
+        },
+        "xl": {
+          "01": {
+            "x": {
+              "value": "0.125rem",
+              "type": "dimension"
+            },
+            "y": {
+              "value": "0.125rem",
+              "type": "dimension"
+            },
+            "blur": {
+              "value": "0.5rem",
+              "type": "dimension"
+            },
+            "spread": {
+              "value": "0rem",
+              "type": "dimension"
+            }
+          },
+          "*02": {
+            "x": {
+              "value": "0rem",
+              "type": "dimension"
+            },
+            "y": {
+              "value": "0.5rem",
+              "type": "dimension"
+            },
+            "blur": {
+              "value": "0.625rem",
+              "type": "dimension"
+            },
+            "spread": {
+              "value": "-0.375rem",
+              "type": "dimension"
+            }
+          }
+        },
+        "*2xl": {
+          "x": {
+            "value": "0rem",
+            "type": "dimension"
+          },
+          "y": {
+            "value": "1.5625rem",
+            "type": "dimension"
+          },
+          "blur": {
+            "value": "3.125rem",
+            "type": "dimension"
+          },
+          "spread": {
+            "value": "-0.75rem",
+            "type": "dimension"
+          }
+        }
+      }
+    },
+    "logo": {
+      "small": {
+        "01": {
+          "value": "{global.16px|1rem}",
+          "type": "dimension"
+        },
+        "02": {
+          "value": "{global.24px|1-5rem}",
+          "type": "dimension"
+        },
+        "03": {
+          "value": "{global.32px|2rem}",
+          "type": "dimension"
+        },
+        "01-p": {
+          "value": "0.038750000298023224rem",
+          "type": "dimension"
+        },
+        "02-p": {
+          "value": "0.0625rem",
+          "type": "dimension"
+        },
+        "03-p": {
+          "value": "0.08312500268220901rem",
+          "type": "dimension"
+        }
+      },
+      "medium": {
+        "01": {
+          "value": "{global.48px|3rem}",
+          "type": "dimension"
+        },
+        "02": {
+          "value": "{global.64px|4rem}",
+          "type": "dimension"
+        },
+        "03": {
+          "value": "{global.256px|16rem}",
+          "type": "dimension"
+        },
+        "01-p": {
+          "value": "0.125rem",
+          "type": "dimension"
+        },
+        "02-p": {
+          "value": "0.16687500476837158rem",
+          "type": "dimension"
+        },
+        "03-p": {
+          "value": "0.25rem",
+          "type": "dimension"
+        }
+      },
+      "large": {
+        "01": {
+          "value": "{global.128px|8rem}",
+          "type": "dimension"
+        },
+        "02": {
+          "value": "{global.256px|16rem}",
+          "type": "dimension"
+        },
+        "03": {
+          "value": "{global.400px|25rem}",
+          "type": "dimension"
+        },
+        "01-p": {
+          "value": "0.3331249952316284rem",
+          "type": "dimension"
+        },
+        "02-p": {
+          "value": "0.6668750047683716rem",
+          "type": "dimension"
+        },
+        "03-p": {
+          "value": "1.0418750047683716rem",
+          "type": "dimension"
+        }
+      }
+    },
+    "margin": {
+      "m": {
+        "0": {
+          "value": "{global.0}",
+          "type": "dimension"
+        },
+        "xxs": {
+          "value": "{global.2px|0125rem}",
+          "type": "dimension"
+        },
+        "sm": {
+          "value": "{global.6px|0375rem}",
+          "type": "dimension"
+        },
+        "md": {
+          "value": "{global.8px|05rem}",
+          "type": "dimension"
+        },
+        "lg": {
+          "value": "{global.12px|075rem}",
+          "type": "dimension"
+        },
+        "xl": {
+          "value": "{global.16px|1rem}",
+          "type": "dimension"
+        },
+        "xs": {
+          "value": "{global.4px|025rem}",
+          "type": "dimension"
+        },
+        "xxxl": {
+          "value": "{global.24px|1-5rem}",
+          "type": "dimension"
+        },
+        "xxl": {
+          "value": "{global.18px|089rem}",
+          "type": "dimension"
+        }
+      }
+    }
+  },
+  "scale-grid/xs": {
+    "col": {
+      "total-col": {
+        "value": "0.25rem",
+        "type": "dimension"
+      },
+      "col-span-1": {
+        "min-col": {
+          "value": "0.25rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.25rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-2": {
+        "min-col": {
+          "value": "0.25rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.25rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-3": {
+        "min-col": {
+          "value": "0.25rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.25rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-4": {
+        "min-col": {
+          "value": "0.25rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.25rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-5": {
+        "min-col": {
+          "value": "0.25rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.25rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-6": {
+        "min-col": {
+          "value": "0.25rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.25rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-7": {
+        "min-col": {
+          "value": "0.25rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.25rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-8": {
+        "min-col": {
+          "value": "0.25rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.25rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-9": {
+        "min-col": {
+          "value": "0.25rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.25rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-10": {
+        "min-col": {
+          "value": "0.25rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.25rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-11": {
+        "min-col": {
+          "value": "0.25rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.25rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-12": {
+        "min-col": {
+          "value": "0.25rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.25rem",
+          "type": "dimension"
+        }
+      }
+    },
+    "margin | gutter": {
+      "margin": {
+        "value": "{margin.m-x.xs}",
+        "type": "dimension"
+      },
+      "gutter": {
+        "value": "{gap.g-x.sm}",
+        "type": "dimension"
+      }
+    },
+    "screen": {
+      "min-w": {
+        "value": "20rem",
+        "type": "dimension"
+      },
+      "max-w": {
+        "value": "0rem",
+        "type": "dimension"
+      },
+      "default-w": {
+        "value": "0rem",
+        "type": "dimension"
+      }
+    }
+  },
+  "scale-grid/sm": {
+    "col": {
+      "total-col": {
+        "value": "0.375rem",
+        "type": "dimension"
+      },
+      "col-span-1": {
+        "min-col": {
+          "value": "0.375rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.375rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-2": {
+        "min-col": {
+          "value": "0.375rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.375rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-3": {
+        "min-col": {
+          "value": "0.375rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.375rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-4": {
+        "min-col": {
+          "value": "0.375rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.375rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-5": {
+        "min-col": {
+          "value": "0.375rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.375rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-6": {
+        "min-col": {
+          "value": "0.375rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.375rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-7": {
+        "min-col": {
+          "value": "0.375rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.375rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-8": {
+        "min-col": {
+          "value": "0.375rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.375rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-9": {
+        "min-col": {
+          "value": "0.375rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.375rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-10": {
+        "min-col": {
+          "value": "0.375rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.375rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-11": {
+        "min-col": {
+          "value": "0.375rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.375rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-12": {
+        "min-col": {
+          "value": "0.375rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.375rem",
+          "type": "dimension"
+        }
+      }
+    },
+    "margin | gutter": {
+      "margin": {
+        "value": "0rem",
+        "type": "dimension"
+      },
+      "gutter": {
+        "value": "0rem",
+        "type": "dimension"
+      }
+    },
+    "screen": {
+      "min-w": {
+        "value": "0rem",
+        "type": "dimension"
+      },
+      "max-w": {
+        "value": "0rem",
+        "type": "dimension"
+      },
+      "default-w": {
+        "value": "0rem",
+        "type": "dimension"
+      }
+    }
+  },
+  "scale-grid/med": {
+    "col": {
+      "total-col": {
+        "value": "0.5rem",
+        "type": "dimension"
+      },
+      "col-span-1": {
+        "min-col": {
+          "value": "0.5rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.5rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-2": {
+        "min-col": {
+          "value": "0.5rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.5rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-3": {
+        "min-col": {
+          "value": "0.5rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.5rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-4": {
+        "min-col": {
+          "value": "0.5rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.5rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-5": {
+        "min-col": {
+          "value": "0.5rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.5rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-6": {
+        "min-col": {
+          "value": "0.5rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.5rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-7": {
+        "min-col": {
+          "value": "0.5rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.5rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-8": {
+        "min-col": {
+          "value": "0.5rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.5rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-9": {
+        "min-col": {
+          "value": "0.5rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.5rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-10": {
+        "min-col": {
+          "value": "0.5rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.5rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-11": {
+        "min-col": {
+          "value": "0.5rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.5rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-12": {
+        "min-col": {
+          "value": "0.5rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.5rem",
+          "type": "dimension"
+        }
+      }
+    },
+    "margin | gutter": {
+      "margin": {
+        "value": "0rem",
+        "type": "dimension"
+      },
+      "gutter": {
+        "value": "0rem",
+        "type": "dimension"
+      }
+    },
+    "screen": {
+      "min-w": {
+        "value": "0rem",
+        "type": "dimension"
+      },
+      "max-w": {
+        "value": "0rem",
+        "type": "dimension"
+      },
+      "default-w": {
+        "value": "0rem",
+        "type": "dimension"
+      }
+    }
+  },
+  "scale-grid/lg": {
+    "col": {
+      "total-col": {
+        "value": "0.75rem",
+        "type": "dimension"
+      },
+      "col-span-1": {
+        "min-col": {
+          "value": "0.75rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.75rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-2": {
+        "min-col": {
+          "value": "0.75rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.75rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-3": {
+        "min-col": {
+          "value": "0.75rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.75rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-4": {
+        "min-col": {
+          "value": "0.75rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.75rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-5": {
+        "min-col": {
+          "value": "0.75rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.75rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-6": {
+        "min-col": {
+          "value": "0.75rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.75rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-7": {
+        "min-col": {
+          "value": "0.75rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.75rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-8": {
+        "min-col": {
+          "value": "0.75rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.75rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-9": {
+        "min-col": {
+          "value": "0.75rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.75rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-10": {
+        "min-col": {
+          "value": "0.75rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.75rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-11": {
+        "min-col": {
+          "value": "0.75rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.75rem",
+          "type": "dimension"
+        }
+      },
+      "col-span-12": {
+        "min-col": {
+          "value": "0.75rem",
+          "type": "dimension"
+        },
+        "max-col": {
+          "value": "0.75rem",
+          "type": "dimension"
+        }
+      }
+    },
+    "margin | gutter": {
+      "margin": {
+        "value": "{margin.m-x.md}",
+        "type": "dimension"
+      },
+      "gutter": {
+        "value": "{gap.g.md}",
+        "type": "dimension"
+      }
+    },
+    "screen": {
+      "min-w": {
+        "value": "60rem",
+        "type": "dimension"
+      },
+      "max-w": {
+        "value": "80rem",
+        "type": "dimension"
+      },
+      "default-w": {
+        "value": "64rem",
+        "type": "dimension"
+      }
+    }
+  },
+  "$themes": [],
+  "$metadata": {
+    "tokenSetOrder": [
+      "global",
+      "color-theme/dark-mode",
+      "color-theme/light-mode",
+      "status/default",
+      "status/hover",
+      "status/focus",
+      "status/active",
+      "color-primitive/color-value",
+      "scale-ui/base",
+      "scale-ui/sm",
+      "scale-ui/lg",
+      "interaction-values/default",
+      "interaction-values/interacted",
+      "text-primitives/static",
+      "num-responsive/mobile",
+      "num-responsive/tablet",
+      "num-responsive/laptop",
+      "num-responsive/desktop",
+      "num-bi-responsive/mobile-tablet",
+      "num-bi-responsive/laptop-desktop",
+      "num-bi-responsive/static",
+      "num-static/static",
+      "scale-grid/xs",
+      "scale-grid/sm",
+      "scale-grid/med",
+      "scale-grid/lg"
+    ]
+  }
+}


### PR DESCRIPTION
Opacity Levels for primitive colors defined
- 0%, 25%, 40%, 60%, 100% 

- Color Levels for all colors 50-900 are updated

Color Groups: 
- Grey : [ Greyscale]
- Brand : [ Jupiter, Saturn, Uranus, Neptune, Nebula, Cosmic ]
- Alert : [ Info, Success, Error, Warning]