### PR TITLE
/ideaspace/workshop/{id} uses only usernames for both the owner and the commentor

### DIFF
--- a/apps/ideaspace/src/components/modules/WorkshoppingPage/CommentsForm/DisplayComments.js
+++ b/apps/ideaspace/src/components/modules/WorkshoppingPage/CommentsForm/DisplayComments.js
@@ -12,10 +12,15 @@ function useForceUpdate() {
 function DisplayComments(props) {
   const commentNodes = props.comments.map((comment) => {
     const commentUser = comment.user;
+    const commentAuthorName =
+      commentUser.username !== undefined
+        ? commentUser.username
+        : commentUser.profile.displayName;
+
     return (
       <Comment
         user={commentUser}
-        author={commentUser.profile.displayName}
+        author={commentAuthorName}
         key={comment.id}
         id={comment.id}
         createdAt={comment.createdAt}

--- a/apps/ideaspace/src/components/modules/WorkshoppingPage/IdeaOverview/IdeaOverview.js
+++ b/apps/ideaspace/src/components/modules/WorkshoppingPage/IdeaOverview/IdeaOverview.js
@@ -15,8 +15,8 @@ export const IdeaOverview = ({ selectedCard }) => {
   if (selectedCard.ideaName === '') return null;
 
   const authorName =
-    selectedCard.ideaOwner?.userName !== undefined
-      ? selectedCard.ideaOwner?.userName
+    selectedCard.ideaOwner?.username !== undefined
+      ? selectedCard.ideaOwner?.username
       : selectedCard.ideaOwner?.email;
 
   return (


### PR DESCRIPTION
-it shows the idea owner by their username not their email
-shows commentor by their username not their full name