### PR TITLE
fix: word break long text string to fit inside of the card.

### DIFF
--- a/apps/ideaspace/src/components/common/IdeaCard/IdeaCard.js
+++ b/apps/ideaspace/src/components/common/IdeaCard/IdeaCard.js
@@ -161,6 +161,7 @@ function IdeaCard({ cards, cardType }) {
                 WebkitBoxOrient: 'vertical',
                 overflow: 'hidden',
                 textOverflow: 'ellipsis',
+                wordBreak: 'break-word',
               }}
             >
               {cards.description}


### PR DESCRIPTION
[Issue](https://github.com/dev-launchers/dev-launchers-platform/issues/2146)

**Change:**
Long string text overflows outside of the card. To fix overflow issue, card style updated to break the word.

**Fix Screenshot:**
<img width="486" alt="image" src="https://github.com/user-attachments/assets/9b971360-681d-4734-b37e-21d5f3ae50bf" />
