### PR TITLE
2195 allow owner to delete the idea

### DIFF
--- a/apps/ideaspace/src/components/common/DialogBox/DeleteConfirmationDialogBox.js
+++ b/apps/ideaspace/src/components/common/DialogBox/DeleteConfirmationDialogBox.js
@@ -13,7 +13,6 @@ import { agent } from '@devlaunchers/utility';
 import { Icons } from '@devlaunchers/components/src/assets';
 
 const DeleteConfirmationDialogBox = ({ card, onClose, onDelete }) => {
-  console.log('DeleteConfirmationDialogBox card', card);
   const [isDeleting, setIsDeleting] = React.useState(false);
   const handleClose = () => {
     onClose(false);
@@ -28,7 +27,6 @@ const DeleteConfirmationDialogBox = ({ card, onClose, onDelete }) => {
     setIsDeleting(true);
     putIdea()
       .then((res) => {
-        console.log('DeleteConfirmationDialogBox res', res);
         if (res.status === 'deleted') {
           onDelete();
         } else {

--- a/apps/ideaspace/src/components/common/DialogBox/DeleteConfirmationDialogBox.js
+++ b/apps/ideaspace/src/components/common/DialogBox/DeleteConfirmationDialogBox.js
@@ -1,0 +1,133 @@
+import React from 'react';
+import {
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+} from '@mui/material';
+import { Loader2, Trash } from 'lucide-react';
+import { atoms } from '@devlaunchers/components/src/components';
+import { cleanData, cleanIdeaForPost } from '../../../utils/StrapiHelper';
+import { agent } from '@devlaunchers/utility';
+import { Icons } from '@devlaunchers/components/src/assets';
+
+const DeleteConfirmationDialogBox = ({ card, onClose, onDelete }) => {
+  console.log('DeleteConfirmationDialogBox card', card);
+  const [isDeleting, setIsDeleting] = React.useState(false);
+  const handleClose = () => {
+    onClose(false);
+  };
+  const putIdea = async () => {
+    const id = card.id;
+    const cardForPut = cleanIdeaForPost(card);
+    cardForPut.data.status = 'deleted';
+    return cleanData(await agent.Ideas.put(id, cardForPut));
+  };
+  const handleConfirm = () => {
+    setIsDeleting(true);
+    putIdea()
+      .then((res) => {
+        console.log('DeleteConfirmationDialogBox res', res);
+        if (res.status === 'deleted') {
+          onDelete();
+        } else {
+          alert('Failed to delete idea!');
+          onDelete();
+        }
+      })
+      .catch((error) => {
+        console.error('Error deleting idea:', error);
+        alert('Error deleting idea. Please try again later.');
+        onDelete();
+      });
+  };
+  return (
+    <Dialog
+      open={true}
+      onClose={handleClose}
+      fullWidth
+      sx={{
+        '& .MuiDialog-paper': {
+          borderRadius: '1rem',
+          width: '25rem',
+        },
+        fontFamily: 'Nunito Sans',
+      }}
+    >
+      <DialogTitle
+        sx={{
+          paddingTop: '16px',
+          paddingBottom: '14px',
+          fontSize: '1rem',
+          fontWeight: 'bold',
+          fontFamily: 'Nunito Sans',
+          lineHeight: '160%',
+          paddingLeft: '20px',
+          paddingRight: '20px',
+        }}
+        className="flex items-center justify-between"
+      >
+        <atoms.Box alignItems="center">Permanently delete this idea?</atoms.Box>
+        <button
+          aria-label="close"
+          onClick={handleClose}
+          className="bg-[#ffffff] text-[#494949] hover:text-[#494949]"
+          disabled={isDeleting}
+        >
+          <Icons.Close height={24} width={24} />
+        </button>
+      </DialogTitle>
+
+      <DialogContent sx={{ padding: '0 20px' }}>
+        <DialogContentText
+          sx={{
+            fontSize: '1rem',
+            paddingBottom: '0.5rem',
+            fontFamily: 'Nunito Sans',
+            color: '#494949',
+            lineHeight: '160%',
+          }}
+        >
+          This action can't be undone. <br />
+          Are you sure you want to delete this idea?
+        </DialogContentText>
+      </DialogContent>
+
+      <DialogActions
+        sx={{
+          height: 'auto',
+          fontSize: '14px',
+          padding: '1.25rem',
+          marginTop: '24px',
+        }}
+        className="border-t border-t-[#4747471a]"
+      >
+        <button
+          className="bg-[#f0edee] rounded-md px-[18px] py-3"
+          onClick={handleClose}
+          disabled={isDeleting}
+        >
+          No, Keep It
+        </button>
+        <button
+          className="bg-[#882D2D] rounded-md px-[18px] py-3 flex items-center justify-center gap-2 text-center text-white"
+          disabled={isDeleting}
+          style={{
+            opacity: isDeleting ? 0.5 : 1,
+          }}
+          onClick={handleConfirm}
+        >
+          {isDeleting ? (
+            <Loader2 size={16} className="animate-spin" />
+          ) : (
+            <Trash size={16} />
+          )}{' '}
+          Yes, Delete
+        </button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default DeleteConfirmationDialogBox;

--- a/apps/ideaspace/src/components/common/DialogBox/DeleteConfirmationDialogBox.js
+++ b/apps/ideaspace/src/components/common/DialogBox/DeleteConfirmationDialogBox.js
@@ -87,8 +87,12 @@ const DeleteConfirmationDialogBox = ({ card, onClose, onDelete }) => {
             lineHeight: '160%',
           }}
         >
-          This action can't be undone. <br />
-          Are you sure you want to delete this idea?
+          <atoms.Typography type="p">
+            This action can't be undone.
+          </atoms.Typography>
+          <atoms.Typography type="p">
+            Are you sure you want to delete this idea?
+          </atoms.Typography>
         </DialogContentText>
       </DialogContent>
 

--- a/apps/ideaspace/src/components/common/SubmissionAlert/DeleteSuccessAlert.js
+++ b/apps/ideaspace/src/components/common/SubmissionAlert/DeleteSuccessAlert.js
@@ -1,0 +1,106 @@
+import React, { useEffect } from 'react';
+import styled from 'styled-components';
+
+const AlertWrapper = styled.div`
+  position: fixed;
+  top: 85px;
+  right: 20px;
+  z-index: 1100;
+  background-color: #c4ebc6;
+  border: 2px solid #226626;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px;
+  animation: fadeIn 0.5s ease-out;
+
+  @keyframes fadeIn {
+    from {
+      opacity: 0;
+      transform: translateY(-20px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+`;
+
+const AlertContent = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+const AlertMessage = styled.h4`
+  color: #206124;
+  margin: 0;
+  font-family: 'Nunito Sans', sans-serif;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 20px;
+`;
+
+const CloseButton = styled.button`
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #226626;
+  padding: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &:hover {
+    opacity: 0.8;
+  }
+`;
+
+const DeleteSuccessAlert = ({ onClose }) => {
+  // Optionally auto-dismiss after 4 seconds.
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      onClose();
+    }, 4000);
+    return () => clearTimeout(timer);
+  }, [onClose]);
+
+  return (
+    <AlertWrapper>
+      <AlertContent>
+        <svg
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M12 2C6.48 2 2 6.48 2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2ZM10 17L5 12L6.41 10.59L10 14.17L17.59 6.58L19 8L10 17Z"
+            fill="#226626"
+          />
+        </svg>
+        <AlertMessage>
+          <b>Idea deleted: </b>Your idea has been successfully deleted
+        </AlertMessage>
+      </AlertContent>
+      <CloseButton onClick={onClose}>
+        <svg
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M19 6.41L17.59 5L12 10.59L6.41 5L5 6.41L10.59 12L5 17.59L6.41 19L12 13.41L17.59 19L19 17.59L13.41 12L19 6.41Z"
+            fill="#226626"
+          />
+        </svg>
+      </CloseButton>
+    </AlertWrapper>
+  );
+};
+
+export default DeleteSuccessAlert;

--- a/apps/ideaspace/src/components/modules/BrowseIdeas/BrowseIdeas.js
+++ b/apps/ideaspace/src/components/modules/BrowseIdeas/BrowseIdeas.js
@@ -103,7 +103,7 @@ function BrowseIdeas() {
     const ideaCards = cleanDataList(
       await agent.Ideas.get(
         new URLSearchParams(
-          `&populate[ideaOwner][populate]&populate[comments][populate]&populate[author][populate]=*&pagination[pageSize]=1000`
+          `&populate[ideaOwner][populate]&populate[comments][populate]&populate[author][populate][profile][populate]&pagination[pageSize]=1000&filters[status][$ne]=deleted`
         )
       )
     );

--- a/apps/ideaspace/src/components/modules/DashboardPage/DashboardPage.js
+++ b/apps/ideaspace/src/components/modules/DashboardPage/DashboardPage.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import { useUserDataContext } from '@devlaunchers/components/context/UserDataContext';
 import { atoms } from '@devlaunchers/components/src/components';
+import { agent } from '@devlaunchers/utility';
 import SignInSection from '../../common/SignInSection/SignInSection';
 import CircularIndeterminateLoader from '../Loader/CircularIndeterminateLoader';
 import Stats from './Stats/Stats';
 import Ideas from './Ideas/Ideas';
 import { cleanDataList, cleanData } from '../../../utils/StrapiHelper';
-import { agent } from '@devlaunchers/utility';
+import DeleteSuccessAlert from '../../common/SubmissionAlert/DeleteSuccessAlert';
 
 import {
   HeadWapper,
@@ -21,9 +22,22 @@ function DashboardPage() {
   const [loading, setLoading] = React.useState(true);
   const [sourceCards, setSourceCards] = React.useState([]);
   const [cards, setCards] = React.useState([]);
+  const [showDeleteAlertSuccess, setShowDeleteAlertSuccess] =
+    React.useState(false);
+
+  // check query string for deleted=true
+  const showAlert = () => {
+    const queryString = window.location.search;
+    const urlParams = new URLSearchParams(queryString);
+    const deleted = urlParams.get('deleted');
+    if (deleted === 'true') {
+      setShowDeleteAlertSuccess(true);
+    }
+  };
 
   React.useEffect(async () => {
     if (isAuthenticated) {
+      showAlert();
       const data = cleanDataList(
         await agent.Ideas.get(new URLSearchParams(`populate=deep`))
       );
@@ -80,6 +94,11 @@ function DashboardPage() {
             <>
               <Stats totalCard={cards} />
               <Ideas totalCard={cards} />
+              {showDeleteAlertSuccess && (
+                <DeleteSuccessAlert
+                  onClose={() => setShowDeleteAlertSuccess(false)}
+                />
+              )}
             </>
           )}
         </PageWrapper>

--- a/apps/ideaspace/src/components/modules/DashboardPage/DashboardPage.js
+++ b/apps/ideaspace/src/components/modules/DashboardPage/DashboardPage.js
@@ -26,11 +26,14 @@ function DashboardPage() {
     React.useState(false);
 
   const showAlert = React.useCallback(() => {
-    if (sessionStorage.getItem('showDeleteAlertSuccess') === 'true') {
+    if (
+      !showDeleteAlertSuccess &&
+      sessionStorage.getItem('showDeleteAlertSuccess') === 'true'
+    ) {
       setShowDeleteAlertSuccess(true);
       sessionStorage.removeItem('showDeleteAlertSuccess');
     }
-  }, []);
+  }, [showDeleteAlertSuccess]);
 
   React.useEffect(async () => {
     if (isAuthenticated) {
@@ -79,17 +82,17 @@ function DashboardPage() {
         </atoms.Typography>
       </HeadWapper>
 
-      {!isAuthenticated ? (
-        <SignInSection
-          label="Please sign in to view your dashboard!"
-          redirectURL={
-            process.env.NEXT_PUBLIC_FRONT_END_URL + '/ideaspace/dashboard'
-          }
-        />
+      {loading === true ? (
+        <CircularIndeterminateLoader text="Loading..." color="black" />
       ) : (
         <PageWrapper>
-          {loading === true ? (
-            <CircularIndeterminateLoader text="Loading..." color="black" />
+          {!isAuthenticated ? (
+            <SignInSection
+              label="Please sign in to view your dashboard!"
+              redirectURL={
+                process.env.NEXT_PUBLIC_FRONT_END_URL + '/ideaspace/dashboard'
+              }
+            />
           ) : (
             <>
               <Stats totalCard={cards} />

--- a/apps/ideaspace/src/components/modules/DashboardPage/DashboardPage.js
+++ b/apps/ideaspace/src/components/modules/DashboardPage/DashboardPage.js
@@ -25,15 +25,12 @@ function DashboardPage() {
   const [showDeleteAlertSuccess, setShowDeleteAlertSuccess] =
     React.useState(false);
 
-  // check query string for deleted=true
-  const showAlert = () => {
-    const queryString = window.location.search;
-    const urlParams = new URLSearchParams(queryString);
-    const deleted = urlParams.get('deleted');
-    if (deleted === 'true') {
+  const showAlert = React.useCallback(() => {
+    if (sessionStorage.getItem('showDeleteAlertSuccess') === 'true') {
       setShowDeleteAlertSuccess(true);
+      sessionStorage.removeItem('showDeleteAlertSuccess');
     }
-  };
+  }, []);
 
   React.useEffect(async () => {
     if (isAuthenticated) {

--- a/apps/ideaspace/src/components/modules/DashboardPage/DashboardPage.js
+++ b/apps/ideaspace/src/components/modules/DashboardPage/DashboardPage.js
@@ -36,9 +36,12 @@ function DashboardPage() {
     if (isAuthenticated) {
       showAlert();
       const data = cleanDataList(
-        await agent.Ideas.get(new URLSearchParams(`populate=deep`))
+        await agent.Ideas.get(
+          new URLSearchParams(
+            `populate=deep&filters[author][id][$eq]=${userData.id}&filters[status][$ne]=deleted`
+          )
+        )
       );
-
       const allCards = data.map((item) => {
         if (item.comments === undefined) item.comments = [];
         else item.comments = cleanDataList(item.comments.data);

--- a/apps/ideaspace/src/components/modules/DashboardPage/StyledDashboardPage.js
+++ b/apps/ideaspace/src/components/modules/DashboardPage/StyledDashboardPage.js
@@ -1,9 +1,9 @@
-import styled from "styled-components";
+import styled from 'styled-components';
 
 export const HeadWapper = styled.div`
-  background-color: #FFFFFF;
+  background-color: #ffffff;
   padding: 7.37rem 1rem 4rem 1rem;
-
+  text-align: center;
   @media (max-width: 1712px) {
     padding: 4.37rem 1rem 2rem 1rem;
   }
@@ -21,7 +21,7 @@ export const Headline = styled.div`
   line-height: 68px;
   text-align: center;
   letter-spacing: -0.02em;
-  color: #1C1C1C;
+  color: #1c1c1c;
 `;
 
 export const StyledRanbow = styled.div`
@@ -34,17 +34,16 @@ export const StyledRanbow = styled.div`
 `;
 
 export const PageWrapper = styled.section`
-  background-color: #FFFFFF;
-  padding: 0rem calc((100% - 75.5rem)/2) 5rem calc((100% - 75.5rem)/2);
+  background-color: #ffffff;
+  padding: 0rem calc((100% - 75.5rem) / 2) 5rem calc((100% - 75.5rem) / 2);
 
   @media (max-width: 1278px) {
-    padding: 0rem calc((100% - 70.5rem)/2) 5rem calc((100% - 70.5rem)/2);
+    padding: 0rem calc((100% - 70.5rem) / 2) 5rem calc((100% - 70.5rem) / 2);
   }
   @media (max-width: 1192px) {
-    padding: 0rem calc((100% - 46.5rem)/2) 5rem calc((100% - 46.5rem)/2);
+    padding: 0rem calc((100% - 46.5rem) / 2) 5rem calc((100% - 46.5rem) / 2);
   }
   @media (max-width: 810px) {
     padding: 0rem 2rem 5rem 2rem;
   }
 `;
-

--- a/apps/ideaspace/src/components/modules/WorkshoppingPage/IdeaOverview/IdeaCard/IdeaCard.js
+++ b/apps/ideaspace/src/components/modules/WorkshoppingPage/IdeaOverview/IdeaCard/IdeaCard.js
@@ -192,9 +192,11 @@ export const IdeaCard = ({
 
   //== Delete Idea
   const handleDeleteIdea = () => {
+    // set sessionStorage to use in the dashboard page
+    sessionStorage.setItem('showDeleteAlertSuccess', 'true');
     setShouldShowDeleteDialog(false);
     window.onbeforeunload = null; // Clear the beforeunload event
-    window.location.href = '/ideaspace/dashboard?deleted=true';
+    window.location.href = '/ideaspace/dashboard';
   };
 
   useEffect(() => {

--- a/apps/ideaspace/src/components/modules/WorkshoppingPage/IdeaOverview/IdeaCard/IdeaCard.js
+++ b/apps/ideaspace/src/components/modules/WorkshoppingPage/IdeaOverview/IdeaCard/IdeaCard.js
@@ -2,6 +2,7 @@ import BookmarkBorderOutlinedIcon from '@mui/icons-material/BookmarkBorderOutlin
 import ShareOutlinedIcon from '@mui/icons-material/ShareOutlined';
 import FavoriteBorderOutlinedIcon from '@mui/icons-material/FavoriteBorderOutlined';
 import StarBorderOutlinedIcon from '@mui/icons-material/StarBorderOutlined';
+import { MoreHorizontal, Trash } from 'lucide-react';
 import {
   StyledCard,
   TopView,
@@ -22,6 +23,16 @@ import { cleanDataList } from '../../../../../utils/StrapiHelper';
 import EditComponent from '../../../../../components/common/IdeaForm/EditComponent';
 import EditIdea from '../../../../../components/modules/EditIdea/EditIdea';
 import EditSuccessAlert from '../../../../../components/common/SubmissionAlert/EditSuccessAlert';
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from '@devlaunchers/components/src/components/Popover/index';
+import {
+  cleanData,
+  cleanIdeaForPost,
+} from '../../../../../utils/StrapiHelper.js';
+import useConfirm from '../../../../../components/common/DialogBox/DialogBox';
 
 export const IdeaCard = ({
   ideaImage,
@@ -32,6 +43,7 @@ export const IdeaCard = ({
   onEditSuccess,
 }) => {
   const [ideaData, setIdeaData] = useState(fullIdea);
+  console.log('fullIdea', fullIdea);
   const [upvoted, setUpvoted] = useState(false);
   const [count, setCount] = useState(0); // number of likes on this idea
   const [showVoteButton, setShowVoteButton] = useState(false);
@@ -183,6 +195,34 @@ export const IdeaCard = ({
     }, 4000);
   };
 
+  //== Delete Idea
+  const [DeleteIdea, confirmDelete] = useConfirm(
+    ['Permanently delete this idea?', 'Error', ''],
+    "This action can't be undone. Are you sure you want to delete this idea?",
+    ['primary alternative', 'Yes, Delete', 'No, Keep it']
+  );
+
+  const handleDeleteIdea = async () => {
+    if (await confirmDelete()) {
+      console.log('Confirmed delete');
+    } else {
+      console.log('Delete cancelled');
+      return;
+    }
+    // const card = { ...fullIdea };
+    // const id = card.id;
+    // const cardForPut = cleanIdeaForPost(card);
+    // const resp = cleanData(await agent.Ideas.put(id, cardForPut));
+    // console.log('resp', resp);
+    // if (resp.status === 200) {
+    //   // Idea deleted successfully
+    //   console.log('Idea deleted successfully');
+    // } else {
+    //   // Handle error
+    //   console.error('Error deleting idea:', resp.error);
+    // }
+  };
+
   useEffect(() => {
     if (isModalOpen) {
       document.body.style.overflow = 'hidden';
@@ -214,7 +254,7 @@ export const IdeaCard = ({
               <div>{upvoteButton}</div>
               <div>
                 {isOwner && (
-                  <>
+                  <div className="flex flex-row gap-2">
                     <button
                       className="h-12 bg-[#494949]/5 rounded-md px-[18px] py-3"
                       onClick={() => setIsModalOpen(true)}
@@ -228,7 +268,30 @@ export const IdeaCard = ({
                       initialIdea={ideaData}
                       onEditSuccess={handleEditSuccess}
                     />
-                  </>
+
+                    <Popover>
+                      <PopoverTrigger asChild>
+                        <button className="h-12 bg-[#494949]/5 rounded-md px-[18px] p-3">
+                          <MoreHorizontal />
+                        </button>
+                      </PopoverTrigger>
+                      <PopoverContent
+                        hasCloseBtn={false}
+                        side="bottom"
+                        align="end"
+                        className="rounded-md w-[224px] h-[60px] p-0"
+                      >
+                        <button
+                          className="flex flex-row gap-2 items-center justify-start text-[#692323] h-full w-full pl-6"
+                          onClick={handleDeleteIdea}
+                        >
+                          <Trash size={18} className="text-[#692323]" />
+                          Delete Idea
+                        </button>
+                      </PopoverContent>
+                    </Popover>
+                    <DeleteIdea />
+                  </div>
                 )}
               </div>
             </div>

--- a/apps/ideaspace/src/components/modules/WorkshoppingPage/IdeaOverview/IdeaCard/IdeaCard.js
+++ b/apps/ideaspace/src/components/modules/WorkshoppingPage/IdeaOverview/IdeaCard/IdeaCard.js
@@ -28,11 +28,7 @@ import {
   PopoverTrigger,
   PopoverContent,
 } from '@devlaunchers/components/src/components/Popover/index';
-import {
-  cleanData,
-  cleanIdeaForPost,
-} from '../../../../../utils/StrapiHelper.js';
-import useConfirm from '../../../../../components/common/DialogBox/DialogBox';
+import DeleteConfirmationDialogBox from '../../../../../components/common/DialogBox/DeleteConfirmationDialogBox.js';
 
 export const IdeaCard = ({
   ideaImage,
@@ -43,14 +39,13 @@ export const IdeaCard = ({
   onEditSuccess,
 }) => {
   const [ideaData, setIdeaData] = useState(fullIdea);
-  console.log('fullIdea', fullIdea);
   const [upvoted, setUpvoted] = useState(false);
   const [count, setCount] = useState(0); // number of likes on this idea
   const [showVoteButton, setShowVoteButton] = useState(false);
   const { userData, isLoading, isAuthenticated } = useUserDataContext();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [showEditSuccess, setShowEditSuccess] = useState(false);
-
+  const [shouldShowDeleteDialog, setShouldShowDeleteDialog] = useState(false);
   const isOwner =
     userData &&
     ideaData &&
@@ -196,31 +191,10 @@ export const IdeaCard = ({
   };
 
   //== Delete Idea
-  const [DeleteIdea, confirmDelete] = useConfirm(
-    ['Permanently delete this idea?', 'Error', ''],
-    "This action can't be undone. Are you sure you want to delete this idea?",
-    ['primary alternative', 'Yes, Delete', 'No, Keep it']
-  );
-
-  const handleDeleteIdea = async () => {
-    if (await confirmDelete()) {
-      console.log('Confirmed delete');
-    } else {
-      console.log('Delete cancelled');
-      return;
-    }
-    // const card = { ...fullIdea };
-    // const id = card.id;
-    // const cardForPut = cleanIdeaForPost(card);
-    // const resp = cleanData(await agent.Ideas.put(id, cardForPut));
-    // console.log('resp', resp);
-    // if (resp.status === 200) {
-    //   // Idea deleted successfully
-    //   console.log('Idea deleted successfully');
-    // } else {
-    //   // Handle error
-    //   console.error('Error deleting idea:', resp.error);
-    // }
+  const handleDeleteIdea = () => {
+    setShouldShowDeleteDialog(false);
+    window.onbeforeunload = null; // Clear the beforeunload event
+    window.location.href = '/ideaspace/dashboard?deleted=true';
   };
 
   useEffect(() => {
@@ -283,14 +257,21 @@ export const IdeaCard = ({
                       >
                         <button
                           className="flex flex-row gap-2 items-center justify-start text-[#692323] h-full w-full pl-6"
-                          onClick={handleDeleteIdea}
+                          onClick={() => setShouldShowDeleteDialog(true)}
                         >
                           <Trash size={18} className="text-[#692323]" />
                           Delete Idea
                         </button>
                       </PopoverContent>
                     </Popover>
-                    <DeleteIdea />
+
+                    {shouldShowDeleteDialog && (
+                      <DeleteConfirmationDialogBox
+                        card={fullIdea}
+                        onClose={setShouldShowDeleteDialog}
+                        onDelete={handleDeleteIdea}
+                      />
+                    )}
                   </div>
                 )}
               </div>
@@ -305,7 +286,10 @@ export const IdeaCard = ({
           </div>
         </div>
         {showEditSuccess && (
-          <EditSuccessAlert onClose={() => setShowEditSuccess(false)} />
+          <EditSuccessAlert
+            onClose={() => setShowEditSuccess(false)}
+            message={['', 'Your changes have been saved!']}
+          />
         )}
       </div>
     </>

--- a/apps/ideaspace/src/components/modules/WorkshoppingPage/WorkshoppingPage.js
+++ b/apps/ideaspace/src/components/modules/WorkshoppingPage/WorkshoppingPage.js
@@ -48,6 +48,13 @@ export default function WorkshoppingPage(props) {
     ['primary', 'got it', '']
   );
 
+  // if the idea is deleted, redirect to dashboard
+  React.useEffect(async () => {
+    if (data.status === 'deleted') {
+      window.location.href = '/ideaspace/dashboard';
+    }
+  }, [data]);
+
   React.useEffect(async () => {
     if (hidden) {
       await confirmArchived();

--- a/apps/ideaspace/src/components/modules/WorkshoppingPage/WorkshoppingPage.js
+++ b/apps/ideaspace/src/components/modules/WorkshoppingPage/WorkshoppingPage.js
@@ -50,7 +50,7 @@ export default function WorkshoppingPage(props) {
 
   // if the idea is deleted, redirect to dashboard
   React.useEffect(async () => {
-    if (data.status === 'deleted') {
+    if (data?.status === 'deleted') {
       window.location.href = '/ideaspace/dashboard';
     }
   }, [data]);


### PR DESCRIPTION
https://github.com/dev-launchers/dev-launchers-platform/issues/2195

Allow idea owner to delete the idea from the dashboard.

Idea card has status field to manage the idea state. For deleting idea, update status to `delete` and call put agent.

https://www.loom.com/share/65e54e27471044feb818fc2e8fe39c75?sid=be4ad85d-35a6-4308-a974-5a51e0cb864d