### PR TITLE
chore(codeowner): change codeowner to anyone on the platform-devs team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,26 +1,2 @@
-# Shared Packages
-packages/ @dev-launchers/platform-enablement
-
-# Design tokens
-packages/tailwind-constructor @dev-launchers/universal-design
-
-# Ideaspace code
-apps/ideaspace/ @dev-launchers/ideaspace-team
-
-# UserProfile code
-apps/user-profile/ @dev-launchers/User-profile
-
-# Recruitment code
-apps/dev-recruiters/ @dev-launchers/dev-recruit 
-
-# Website code
-apps/website/ @dev-launchers/platform-enablement
-
-# Website code
-apps/app/ @dev-launchers/platform-enablement
-
-# Code in the backend directory
-strapiv4/ @dev-launchers/Backend-Devs
-
-# Deps
-package.json @dev-launchers/platform-enablement
+# Default owner for every files
+* @dev-launchers/platform-devs


### PR DESCRIPTION
As we transition into a wider development department, developers will often work on apps in different projects