### PR TITLE
Fix #2594: Center 'View current open roles' button on join confirmation

### DIFF
--- a/apps/dev-recruiters/src/components/modules/TalcommunityPage/TalFormPage/signUpForm.tsx
+++ b/apps/dev-recruiters/src/components/modules/TalcommunityPage/TalFormPage/signUpForm.tsx
@@ -162,12 +162,14 @@ export default function TalCommForm({ handleCloseModal }: Props) {
                     <atoms.Checkbox
                       label="I am 18 years old or older."
                       disabled={false}
+                      checked={ageCheckbox}
                       onChange={handleSetAgeCheckbox}
                       required
                     />
                     <atoms.Checkbox
                       label="I have read and agreed to the terms and conditions"
                       disabled={false}
+                      checked={termsCheckbox}
                       onChange={handleSetTermsCheckbox}
                       required
                     />

--- a/apps/dev-recruiters/src/components/modules/ThankyouPage/index.tsx
+++ b/apps/dev-recruiters/src/components/modules/ThankyouPage/index.tsx
@@ -27,10 +27,12 @@ export function ThankyouPage() {
             We will email you when a volunteer role that matches your skillsets
             and/or interests opens up!
           </SubHeaderContainer>
-          <BoxContainer paddingVertical={80} paddingHorizontal={520}>
-            <BtnSignUp as="a" type="submit" onClick={routeChange}>
-              VIEW CURRENT OPEN ROLES
-            </BtnSignUp>
+          <BoxContainer paddingVertical={80} paddingHorizontal={24}>
+            <div style={{ display: 'flex', justifyContent: 'center' }}>
+              <BtnSignUp as="a" type="submit" onClick={routeChange}>
+                VIEW CURRENT OPEN ROLES
+              </BtnSignUp>
+            </div>
           </BoxContainer>
         </BoxContainer>
       </Wrapper>


### PR DESCRIPTION
This PR fixes #2594 

The "View current open roles" button was misaligned after submitting the talent community form. Checkboxes also were not working on the join/second page