### PR TITLE
Fix: Allow only idea owner to edit image

### DIFF
--- a/apps/ideaspace/src/components/common/IdeaCard/IdeaCard.js
+++ b/apps/ideaspace/src/components/common/IdeaCard/IdeaCard.js
@@ -120,7 +120,7 @@ function IdeaCard({ cards, cardType }) {
         <IdeaCardTag status={tagContent} />
       </atoms.Box> */}
         <div>
-          {cards.ideaImage && cards.ideaImage?.data?.attributes?.medium_url ? (
+          {cards.ideaImage?.data?.attributes?.medium_url ? (
             <IdeaCardImg
               key={cards.id}
               cardId={cards.id}

--- a/apps/ideaspace/src/components/modules/WorkshoppingPage/IdeaOverview/IdeaCard/IdeaCard.js
+++ b/apps/ideaspace/src/components/modules/WorkshoppingPage/IdeaOverview/IdeaCard/IdeaCard.js
@@ -29,6 +29,7 @@ import {
 } from '@devlaunchers/components/src/components/Popover/index';
 import DeleteConfirmationDialogBox from '../../../../../components/common/DialogBox/DeleteConfirmationDialogBox.js';
 import { ImageBanner } from './ImageBanner';
+import { ImagePreviewSVG } from '../../../../common/SVG/ImagePreview';
 
 export const IdeaCard = ({
   ideaImage,
@@ -305,11 +306,24 @@ export const IdeaCard = ({
               </div>
             </div>
           </div>
-          <ImageBanner
-            bannerImage={bannerImage}
-            updateIdeaImage={handleUpdateIdeaImage}
-            ideaId={ideaId}
-          />
+          {isOwner ? (
+            <ImageBanner
+              bannerImage={bannerImage}
+              updateIdeaImage={handleUpdateIdeaImage}
+              ideaId={ideaId}
+            />
+          ) : (
+            <div
+              className={`w-full h-[304px] rounded-2xl flex items-center justify-center bg-cover bg-center bg-no-repeat ${
+                !bannerImage ? 'bg-[#F6F6F6]' : ''
+              }`}
+              {...(bannerImage && {
+                style: { backgroundImage: `url(${bannerImage.original_url})` },
+              })}
+            >
+              {!bannerImage && <ImagePreviewSVG />}
+            </div>
+          )}
         </div>
         {showEditSuccess && (
           <Alert


### PR DESCRIPTION
This PR implements the fix to allow only idea owner to edit idea image.

Not Idea owner:
<img width="705" height="613" alt="image" src="https://github.com/user-attachments/assets/4be682a7-f744-4694-b593-84345707cb32" />
<img width="705" height="619" alt="image" src="https://github.com/user-attachments/assets/fcb49ba1-c314-4625-b270-4708fad4d8fa" />

Idea Owner:
<img width="689" height="605" alt="image" src="https://github.com/user-attachments/assets/bcfdd727-52e4-47dc-9206-af0d6ebc47b3" />
<img width="689" height="640" alt="image" src="https://github.com/user-attachments/assets/fe76d0f1-dea5-4a95-8c5d-c8f079423fb0" />
