### PR TITLE
fix: #2696 - Display “idea name already in use” error when clicking o…

### DIFF
--- a/packages/utility/agent.ts
+++ b/packages/utility/agent.ts
@@ -81,7 +81,7 @@ const responseBody = (response: AxiosResponse) =>
 const errorBody = (error: AxiosError) => (error ? error : null);
 
 const requests = {
-  get: <T>(url: string, params?: URLSearchParams) =>
+  get: <T>(url: string, params?: any) =>
     axios.get<T>(url, { params }).then(responseBody).catch(errorBody),
   post: <T>(url: string, body: {}) =>
     axios.post<T>(url, { data: body }).then(responseBody),
@@ -158,6 +158,9 @@ const Ideas = {
     requests.get<Idea>(`/idea-cards/${id}`, params),
   post: (body: {}) => requests.post<Idea>('/idea-cards/', body),
   put: (id: string, body: {}) => requests.put<Idea>(`/idea-cards/${id}`, body),
+  findByName: (name: string) => {
+    return requests.get('idea-cards?filters[ideaName][$eqi]='+name);
+  },
 };
 
 const User = {


### PR DESCRIPTION
## Background
This PR enables the following behavior:

1. When a user enters an idea name that already exists and clicks outside the input field, the system validates the name. If the idea name is already taken, the error message: “This idea name is already in use. Please try something else.” is displayed.
2. The error message appears below the input field and remains visible until the user edits the input. When the user updates the idea name to a unique value, the error message disappears automatically.
3. Same behavior works on hitting Tab and in Edit Idea Form. 

## Testing
* Tested behavior on localhost