### PR TITLE
fix: #2720: disables save changes and submit idea in idea form by default

### DIFF
--- a/apps/ideaspace/src/components/common/IdeaForm/EditComponent.js
+++ b/apps/ideaspace/src/components/common/IdeaForm/EditComponent.js
@@ -10,10 +10,13 @@ const EditComponent = ({
   onEditSuccess,
   onEditError,
 }) => {
+  const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
   const [windowWidth, setWindowWidth] = React.useState(window.innerWidth);
   const [windowHeight, setWindowHeight] = React.useState(window.innerHeight);
   const editIdeaRef = useRef(null);
   const [isSubmitting, setIsSubmitting] = React.useState(false);
+  const [canSaveForm, setCanSaveForm] = useState(false);
+
 
   // Add a key state to force re-render of EditIdea component
   const [componentKey, setComponentKey] = React.useState(Date.now());
@@ -31,7 +34,8 @@ const EditComponent = ({
   useEffect(() => {
     if (open) {
       setComponentKey(Date.now()); // Generate a new key to force re-render
-
+      setHasUnsavedChanges(false);
+      setCanSaveForm(false);
       // Clear any localStorage cache
       localStorage.removeItem('ideaFormData');
       localStorage.removeItem('involveLevel');
@@ -92,7 +96,7 @@ const EditComponent = ({
     'bg-transparent border-0 text-[1.25rem] cursor-pointer';
 
   const handleSave = async () => {
-    if (editIdeaRef.current) {
+    if (editIdeaRef.current && hasUnsavedChanges) {
       setIsSubmitting(true);
       try {
         editIdeaRef.current.touchAllFields();
@@ -158,6 +162,8 @@ const EditComponent = ({
               initialIdea={initialIdea}
               onEditSuccess={handleEditSuccess}
               onEditError={handleEditError}
+              onUnsavedChanges={setHasUnsavedChanges}
+              onCanSave={setCanSaveForm}
             />
           )}
         </div>
@@ -173,17 +179,23 @@ const EditComponent = ({
             Cancel
           </atoms.Button>
           {/* Add an explicit spacer */}
-          <div style={{ width: '12px' }}></div>
-          <atoms.Button
-            type="primary"
-            size="medium"
-            mode="light"
-            color="nebula"
-            disabled={isSubmitting || isSending}
-            onClick={handleSave}
+          <div style={{width: '12px'}}></div>
+          <div
+            style={{
+              opacity: (!canSaveForm || isSubmitting || isSending) ? 0.5 : 1,
+              cursor: (!canSaveForm || isSubmitting || isSending) ? 'not-allowed' : 'pointer',
+            }}
           >
-            {isSubmitting || isSending ? 'Wait' : 'Save Changes'}
-          </atoms.Button>
+            <atoms.Button
+              type="primary"
+              size="medium"
+              mode="light"
+              color="nebula"
+              onClick={handleSave}
+            >
+              {isSubmitting || isSending ? 'Wait' : 'Save Changes'}
+            </atoms.Button>
+          </div>
         </div>
       </div>
     </div>

--- a/apps/ideaspace/src/components/common/IdeaForm/EditionButton.js
+++ b/apps/ideaspace/src/components/common/IdeaForm/EditionButton.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { atoms } from '@devlaunchers/components/src/components';
 
-const EditionButton = ({ clickHandlerButton, sending, disabling }) => {
+const EditionButton = ({ clickHandlerButton, sending, onClick, style, className, disabling, }) => {
   const goBack = () => {
     clickHandlerButton('back');
   };
@@ -17,16 +17,18 @@ const EditionButton = ({ clickHandlerButton, sending, disabling }) => {
       >
         CANCEL
       </atoms.Button>
-      <atoms.Button
-        buttonSize="medium"
-        type="primary"
-        mode="light"
-        color="nebula"
-        disabled={disabling}
-      >
-        {' '}
-        {sending === true ? 'Wait' : 'Save edits'}{' '}
-      </atoms.Button>
+      <div style={style} className={className}>
+        <atoms.Button
+          buttonSize="medium"
+          type="primary"
+          mode="light"
+          color="nebula"
+          onClick={onClick}
+          disabled={disabling || sending} 
+        >
+          {sending === true ? 'Wait' : 'Save edits'}
+        </atoms.Button>
+      </div>
     </>
   );
 };

--- a/apps/ideaspace/src/components/common/IdeaForm/IdeaForm.js
+++ b/apps/ideaspace/src/components/common/IdeaForm/IdeaForm.js
@@ -29,13 +29,41 @@ import {
 import Alert from '../SubmissionAlert/Alert.js';
 import { agent } from '@devlaunchers/utility';
 
+const CASE_INSENSITIVE_FIELDS = ['ideaName'];
+
 const compareValuesToInitial = (values, initialValues) => {
-  const name = Object.keys(values);
-  for (let i = 0; i < name.length; i++) {
-    if (values[name[i]] !== initialValues[name[i]]) {
-      return true;
+  const keys = Object.keys(values);
+
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i];
+    const valueItem = values[key];
+    const initialItem = initialValues[key];
+
+    if (valueItem === null && initialItem === null) continue;
+    if (valueItem === undefined && initialItem === undefined) continue;
+    if (valueItem === null || initialItem === null) return true;
+    if (valueItem === undefined || initialItem === undefined) return true;
+
+    if (typeof valueItem === 'object' && typeof initialItem === 'object') {
+      if (JSON.stringify(valueItem) !== JSON.stringify(initialItem)) {
+        return true;
+      }
+    }
+    else if (
+      CASE_INSENSITIVE_FIELDS.includes(key) &&
+      typeof valueItem === 'string' &&
+      typeof initialItem === 'string'
+    ) {
+      if (valueItem.trim().toLowerCase() !== initialItem.trim().toLowerCase()) {
+        return true;
+      }
+    } else {
+      if (valueItem !== initialItem) {
+        return true;
+      }
     }
   }
+
   return false;
 };
 
@@ -53,35 +81,41 @@ const clearLocalStorage = () => {
   localStorage.removeItem('involveLevel');
 };
 
-const AutoSubmitToken = ({ setDisabling, unsavedHandler, initialValues }) => {
+const AutoSubmitToken = ({ setDisabling, unsavedHandler, initialValues, editMode }) => {
   const { values } = useFormikContext();
   const [previousValues, setPreviousValues] = useState(values);
   React.useEffect(() => {
-    autoSaveLocalStorage(values);
-    if (compareValuesToInitial(values, initialValues)) {
+    // Only save to localStorage if NOT in edit mode
+    if (!editMode) {
+      autoSaveLocalStorage(values);
+    }
+
+    const hasChanges = compareValuesToInitial(values, initialValues);
+
+    if (hasChanges) {
       unsavedHandler(true);
       setDisabling(false);
-    } else if (JSON.stringify(values) !== JSON.stringify(previousValues)) {
+    } else {
       unsavedHandler(false);
       setDisabling(true);
-      setPreviousValues(values);
     }
-  }, [values, previousValues, initialValues, setDisabling, unsavedHandler]);
+  }, [values, initialValues, setDisabling, unsavedHandler, editMode]);
   return null;
 };
 
 const IdeaForm = ({
-  initialValues,
-  SignupSchema,
-  submitHandler,
-  unsavedHandler,
-  formButton,
-  sending,
-  clickHandler,
-  editMode,
-  hideFormButtons = false,
-  formikRef = null,
-}) => {
+                    initialValues,
+                    SignupSchema,
+                    submitHandler,
+                    unsavedHandler,
+                    canSaveHandler,
+                    formButton,
+                    sending,
+                    clickHandler,
+                    editMode,
+                    hideFormButtons = false,
+                    formikRef = null,
+                  }) => {
   const [focusedField, setFocusedField] = useState(null);
   const [disabling, setDisabling] = React.useState(true);
   const { isMobile } = useResponsive();
@@ -105,8 +139,8 @@ const IdeaForm = ({
     setFocusedField(fieldName);
   };
 
-  const savedData = loadFromLocalStorage();
-  const newInitialValues = { ...initialValues, ...savedData };
+  const savedData = editMode ? null : loadFromLocalStorage();
+  const newInitialValues = savedData ? { ...initialValues, ...savedData } : initialValues;
 
   React.useEffect(() => {
     localStorage.removeItem('ideaFormData');
@@ -215,24 +249,48 @@ const IdeaForm = ({
           innerRef={formikRef}
         >
           {({
-            values,
-            setFieldValue,
-            errors,
-            touched,
-            handleBlur,
-            submitForm,
-            isValid,
-            setFieldTouched,
-            validateForm,
-            handleChange,
-            handleSubmit,
-            isSubmitting,
-          }) => (
+              values,
+              setFieldValue,
+              errors,
+              touched,
+              handleBlur,
+              submitForm,
+              isValid,
+              setFieldTouched,
+              validateForm,
+              handleChange,
+              handleSubmit,
+              isSubmitting,
+            }) => {
+
+            const requiredFieldsFilled =
+              values.ideaName?.trim() &&
+              values.description?.trim() &&
+              values.experience?.trim() &&
+              values.targetAudience?.trim() &&
+              values.features?.trim();
+
+            const canSubmit =
+              Boolean(requiredFieldsFilled) && isValid && !nameTaken;
+
+            const canSave = canSubmit && !disabling;
+
+            React.useEffect(() => {
+              if (canSaveHandler && editMode) {
+                canSaveHandler(canSave);
+              }
+            }, [canSave, canSaveHandler, editMode]);
+
+            const canPostIdea = canSubmit && isChecked;
+
+            return (
+
             <Form>
               <AutoSubmitToken
                 setDisabling={setDisabling}
                 unsavedHandler={unsavedHandler}
                 initialValues={initialValues}
+                editMode={editMode}
               />
               {/* {!editMode && (
                 <atoms.Typography type="h4">
@@ -682,6 +740,10 @@ const IdeaForm = ({
                     {formButton == 'submit' ? (
                       <SubmissionButton
                         sending={sending}
+                        style={{
+                          opacity: canPostIdea ? 1 : 0.5,
+                          cursor: canPostIdea ? 'pointer' : 'not-allowed',
+                        }}
                         onClick={async (e) => {
                           e.preventDefault();
 
@@ -691,24 +753,34 @@ const IdeaForm = ({
                             'experience',
                             'targetAudience',
                             'features',
-                            //                            'involveLevel',
                           ];
                           fields.forEach((field) =>
                             setFieldTouched(field, true)
                           );
 
                           const validationErrors = await validateForm();
+
+                          if (nameTaken) {
+                            validationErrors.ideaName =
+                              'This idea name is already in use. Please try something else.';
+                          }
+
+                          // Block submit but still scroll
                           if (Object.keys(validationErrors).length > 0) {
                             scrollToError(validationErrors);
                             return;
                           }
-                          //  Updated T&C checkbox validation
-                          if (!isChecked) {
-                            alert(
-                              'You must accept the Terms & Conditions to submit the form.'
-                            );
-                            return; // Preventing form submission if T&C is not checked
+
+                          // Block if can't post idea (T&C or otherwise)
+                          if (!canPostIdea) {
+                            if (!isChecked) {
+                              alert(
+                                'You must accept the Terms & Conditions to submit the form.'
+                              );
+                            }
+                            return;
                           }
+
                           try {
                             await submitForm();
                           } catch (error) {
@@ -721,13 +793,43 @@ const IdeaForm = ({
                         clickHandlerButton={clickHandler}
                         sending={sending}
                         disabling={disabling}
+                        style={{
+                          opacity: canSave ? 1 : 0.5,
+                          cursor: canSave ? 'pointer' : 'not-allowed',
+                        }}
                         onClick={async (e) => {
                           e.preventDefault();
+                          const fields = [
+                            'ideaName',
+                            'description',
+                            'experience',
+                            'targetAudience',
+                            'features',
+                          ];
+
+                          // Mark required fields as touched
+                          fields.forEach((field) =>
+                            setFieldTouched(field, true)
+                          );
+
+                          const validationErrors = await validateForm();
+
+                          if (nameTaken) {
+                            validationErrors.ideaName =
+                              'This idea name is already in use. Please try something else.';
+                          }
+
+                          if (Object.keys(validationErrors).length > 0) {
+                            scrollToError(validationErrors);
+                            return;
+                          }
+
+                          if (!canSave) {
+                            return;
+                          }
+
                           try {
                             await submitForm();
-                            if (Object.keys(errors).length > 0) {
-                              scrollToError(errors);
-                            }
                           } catch (error) {
                             console.error('Form submission error:', error);
                           }
@@ -741,6 +843,7 @@ const IdeaForm = ({
                   setDisabling={setDisabling}
                   unsavedHandler={unsavedHandler}
                   initialValues={initialValues}
+                  editMode={editMode}
                 />
               </atoms.Box>
               {successMessageVisible && (
@@ -760,7 +863,7 @@ const IdeaForm = ({
                 />
               )}
             </Form>
-          )}
+          )}}
         </Formik>
       </atoms.Box>
     </atoms.Box>

--- a/apps/ideaspace/src/components/common/IdeaForm/SubmissionButton.js
+++ b/apps/ideaspace/src/components/common/IdeaForm/SubmissionButton.js
@@ -1,18 +1,19 @@
 import React from 'react';
 import { atoms } from '@devlaunchers/components/src/components';
 
-const SubmissionButton = ({ sending, onClick }) => {
+const SubmissionButton = ({ sending, onClick, style, className }) => {
   return (
-    <atoms.Button
-      color="nebula"
-      size="standard"
-      type="primary"
-      mode="light"
-      onClick={onClick}
-    >
-      {' '}
-      {sending === true ? 'Wait' : 'Post Idea'}{' '}
-    </atoms.Button>
+    <div style={style} className={className}>
+      <atoms.Button
+        color="nebula"
+        size="standard"
+        type="primary"
+        mode="light"
+        onClick={onClick}
+      >
+        {sending === true ? 'Wait' : 'Post Idea'}
+      </atoms.Button>
+    </div>
   );
 };
 

--- a/apps/ideaspace/src/components/modules/EditIdea/EditIdea.js
+++ b/apps/ideaspace/src/components/modules/EditIdea/EditIdea.js
@@ -13,7 +13,7 @@ import * as Yup from 'yup';
 
 import { HeadWapper, Headline, StyledRanbow } from './StyledEditIdea';
 
-const EditIdea = forwardRef(({ initialIdea, onEditSuccess }, ref) => {
+const EditIdea = forwardRef(({ initialIdea, onEditSuccess, onUnsavedChanges, onCanSave }, ref) => {
   let { userData, isAuthenticated } = useUserDataContext();
   const formikRef = useRef();
   const router = useRouter();
@@ -307,7 +307,13 @@ const EditIdea = forwardRef(({ initialIdea, onEditSuccess }, ref) => {
               initialValues={card}
               SignupSchema={SignupSchema}
               submitHandler={submitHandler}
-              unsavedHandler={setunsavedChanges}
+              unsavedHandler={(hasChanges) => {
+                setunsavedChanges(hasChanges);
+                if (onUnsavedChanges) {
+                  onUnsavedChanges(hasChanges);
+                }
+              }}
+              canSaveHandler={onCanSave}
               formButton="save"
               sending={sending}
               clickHandler={backHandler}


### PR DESCRIPTION
## Background
This PR enables the following behavior:

* The Post Idea and Save Changes button is disabled by default
* Both buttons become enabled only when:
** All required fields are filled
** All inputs pass validation

* If a field becomes invalid again, the button is disabled automatically
* If a user tries to click a disabled button "post idea" / "save changes" it scrolls up to the invalid or empty field
* the disabled "post idea" button does not submit/post idea and the "save changes" button does not save changes

## Testing
Tested behavior on localhost & demoed in Collab call