### PR TITLE
IdeaSpace: Removed ideaOwner populate from query

### DIFF
--- a/apps/ideaspace/src/components/modules/BrowseIdeas/BrowseIdeas.js
+++ b/apps/ideaspace/src/components/modules/BrowseIdeas/BrowseIdeas.js
@@ -107,7 +107,7 @@ function BrowseIdeas() {
     const ideaCards = cleanDataList(
       await agent.Ideas.get(
         new URLSearchParams(
-          `&populate[ideaOwner][populate]&populate[ideaImage][populate]&populate[comments][populate]&populate[author][populate][profile][populate]&pagination[pageSize]=1000&filters[status][$ne]=deleted`
+          `&populate[ideaImage][populate]&populate[comments][populate]&populate[author][populate][profile][populate]&pagination[pageSize]=1000&filters[status][$ne]=deleted`
         )
       )
     );


### PR DESCRIPTION
[Investigate and Improve Page Load Time for Browse Ideas page to Reduce Drop-Offs](https://github.com/dev-launchers/dev-launchers-platform/pull/2749) 
IdeaSpace browse page query - removed ideaOwner populate from the api call. I couldn't find any trace where ideaOwner values are used. Query also fetches author object, which is used to display user name, profile image.