### PR TITLE
Improve sign-in prompt in Comment Feed (Workshopping page) #2778

### DIFF
--- a/apps/ideaspace/src/components/common/SignInSection/SignInSection.js
+++ b/apps/ideaspace/src/components/common/SignInSection/SignInSection.js
@@ -1,13 +1,15 @@
 import React from 'react';
 import Link from 'next/link';
-import { atoms } from '@devlaunchers/components/src/components';
+import { Button, Box } from '@devlaunchers/components/src/components/atoms';
 import { SignInWrapper } from './StyledSignInSection';
 
-const SignInSection = ({ label, redirectURL }) => {
+const SignInSection = ({ label, redirectURL, headerTitle }) => {
   return (
     <SignInWrapper>
-      <atoms.Box flexDirection="column">{label}</atoms.Box>
-      <br />
+      <Box flexDirection="column">
+        <span className="text-2xl mb-2">{headerTitle}</span>
+        <span className="text-sm md:text-lg mb-4">{label}</span>
+      </Box>
       <Link
         href={
           process.env.NEXT_PUBLIC_GOOGLE_AUTH_URL +
@@ -15,9 +17,9 @@ const SignInSection = ({ label, redirectURL }) => {
           redirectURL
         }
       >
-        <atoms.Button size="small" type="primary" color="nebula" mode="light">
-          Sign&nbsp;in
-        </atoms.Button>
+        <Button size="small" type="primary" color="nebula" mode="light">
+          Sign in
+        </Button>
       </Link>
     </SignInWrapper>
   );

--- a/apps/ideaspace/src/components/common/SignInSection/StyledSignInSection.js
+++ b/apps/ideaspace/src/components/common/SignInSection/StyledSignInSection.js
@@ -1,11 +1,13 @@
-import styled from "styled-components";
+import styled from 'styled-components';
 
 export const SignInWrapper = styled.div`
-  background-color: #FFFFFF;
+  background: var(--base-03, #1c1c1c);
+  color: var(--content-01, #c5bfbf);
   border-radius: 32px;
-  max-width: 36rem;
+  max-width: 48rem;
   margin: 4.5rem auto;
   padding: 2rem;
+  font-family: var(--text-family-mode-family, 'Nunito Sans');
 
   @media (max-width: 1712px) {
     margin: 3rem auto;

--- a/apps/ideaspace/src/components/modules/SubmissionForm/SubmissionForm.js
+++ b/apps/ideaspace/src/components/modules/SubmissionForm/SubmissionForm.js
@@ -231,12 +231,14 @@ function SubmissionForm() {
       </HeadWapper>
 
       {!isAuthenticated ? (
-        <SignInSection
-          label="Please sign in to submit your idea!"
-          redirectURL={
-            process.env.NEXT_PUBLIC_FRONT_END_URL + '/ideaspace/submit'
-          }
-        />
+        <HeadWapper style={{ textAlign: 'left' }}>
+          <SignInSection
+            label="Please sign in to submit your idea!"
+            redirectURL={
+              process.env.NEXT_PUBLIC_FRONT_END_URL + '/ideaspace/submit'
+            }
+          />
+        </HeadWapper>
       ) : (
         <>
           <Dialog />

--- a/apps/ideaspace/src/components/modules/WorkshoppingPage/CommentsForm/CommentForm.js
+++ b/apps/ideaspace/src/components/modules/WorkshoppingPage/CommentsForm/CommentForm.js
@@ -54,7 +54,7 @@ function CommentForm(props) {
 
   // move to WorkshoppingPage?
   return (
-    <div className="container">
+    <div className="w-full">
       {isAuthenticated ? (
         <form
           onSubmit={handleSubmit}
@@ -94,7 +94,7 @@ function CommentForm(props) {
                     e.currentTarget.style.border = 'none';
                   }}
                   type="submit"
-                  className="rounded-full text-white"
+                  className="rounded-full text-white send-button"
                   style={{
                     position: 'absolute',
                     right: '10px',
@@ -116,7 +116,8 @@ function CommentForm(props) {
         </form>
       ) : (
         <SignInSection
-          label="Sign in to leave a comment or like."
+          label="Sign in or create an account to upvote ideas and join the discussion"
+          headerTitle="Want to join the discussion?"
           redirectURL={
             process.env.NEXT_PUBLIC_FRONT_END_URL +
             '/ideaspace/workshop/' +

--- a/apps/ideaspace/src/components/modules/WorkshoppingPage/CommentsForm/StyledComments.js
+++ b/apps/ideaspace/src/components/modules/WorkshoppingPage/CommentsForm/StyledComments.js
@@ -128,7 +128,7 @@ export const Form = styled.div`
     border-radius: 25px;
   }
 
-  button {
+  .send-button {
     display: flex;
     height: 36px;
     width: 36px;
@@ -142,11 +142,11 @@ export const Form = styled.div`
     background: var(--btn-surface-brand-primary, #52287a);
   }
 
-  button:hover {
+  .send-button:hover {
     cursor: pointer;
     border-color: #52287a;
   }
-  button:focus {
+  .send-button:focus {
     border: var(--btn-border-width, 4px) solid
       var(--btn-border-brand-primary, #3f1f5f);
   }


### PR DESCRIPTION
### Issue
The sign-in prompt in the Comment Feed had inconsistent styling with dark mode and used a non-standard button design.

Additionally, a generic `button {}` selector in CommentForm caused unintended styling across components (e.g., SignInSection).


### Changes
- Redesigned sign-in card to match dark mode UI
- Updated title and supporting text for better clarity
- Replaced button with primary purple button from Storybook
- Scoped comment form button styles using `.send-button` class
- Ensured consistent spacing, layout, and responsiveness

#2778 