### PR TITLE
Bugfix/2785 : Front end fix for Idea Name Cannot Be Reused After Deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,26 @@ The release cadence is every 4 weeks. We will create a PR to merge the master br
 
 ---
 
+## Local Development Setup
+
+To run the project locally for testing, configure your environment variables in:
+
+`apps/app/.env.development`
+
+If the file does not exist, create it.
+
+Add the following values:
+
+NEXT_PUBLIC_NAME=DEVELOPMENT\
+NEXT_PUBLIC_API_BASE_URL=http://localhost:1337\
+NEXT_PUBLIC_API_URL=http://localhost:1337/api\
+NEXT_PUBLIC_STRAPI_URL=http://localhost:1337/api\
+NEXT_PUBLIC_GOOGLE_AUTH_URL=http://localhost:1337/api/connect/google\
+NEXT_PUBLIC_DISCORD_AUTH_URL=https://discord.com/api/oauth2/authorize?client_id=815294711983112194&redirect_uri=https%3A%2F%2Fapi-staging.devlaunchers.org%2Fusers%2Fauth%2Fdiscord%2Fcallback&response_type=code&scope=identify\
+NEXT_PUBLIC_FRONT_END_URL=http://localhost:3000
+
+---
+
 ## Monorepo scripts
 
 Some convenience scripts can be run in any folder of this repo and will call their counterparts defined in packages and apps.

--- a/README.md
+++ b/README.md
@@ -41,23 +41,52 @@ The release cadence is every 4 weeks. We will create a PR to merge the master br
 
 ---
 
+## Local Development Login
+
+To login to Devlauncher in local environment, please follow the steps below:
+
+1. Ensure you are log out for both staging and development Devlauncher website and keep both of these open in browser
+
+2. Change .env.devlopment file to match what it is in master branch as shown below:  
+   `NEXT_PUBLIC_NAME=DEVELOPMENT`
+   `NEXT_PUBLIC_API_BASE_URL=https://apiv4-staging.devlaunchers.org`  
+   `NEXT_PUBLIC_API_URL=https://apiv4-staging.devlaunchers.org/api`  
+   `NEXT_PUBLIC_STRAPI_URL=https://apiv4-staging.devlaunchers.org/api`  
+   `NEXT_PUBLIC_GOOGLE_AUTH_URL=https://apiv4-staging.devlaunchers.org/api/connect/google`  
+   `NEXT_PUBLIC_DISCORD_AUTH_URL=https://discord.com/api/oauth2/authorize?client_id=815294711983112194&redirect_uri=https%3A%2F%2Fapi-staging.devlaunchers.org%2Fusers%2Fauth%2Fdiscord%2Fcallback&response_type=code&scope=identify`  
+   `NEXT_PUBLIC_FRONT_END_URL=http://localhost:3000`
+
+3. Login to your profile using staging Devlauncher website
+
+4. Once you are login, you can edit the .env.devlopment file to connect to your local api instead  
+   `NEXT_PUBLIC_NAME=DEVELOPMENT`  
+   `NEXT_PUBLIC_API_BASE_URL=http://localhost:1337`  
+   `NEXT_PUBLIC_API_URL=http://localhost:1337/api`  
+   `NEXT_PUBLIC_STRAPI_URL=http://localhost:1337/api`  
+   `NEXT_PUBLIC_GOOGLE_AUTH_URL=http://localhost:1337/api/connect/google`  
+   `NEXT_PUBLIC_DISCORD_AUTH_URL=https://discord.com/api/oauth2/authorize?client_id=815294711983112194&redirect_uri=https%3A%2F%2Fapi-staging.devlaunchers.org%2Fusers%2Fauth%2Fdiscord%2Fcallback&response_type=code&scope=identify`  
+   `NEXT_PUBLIC_FRONT_END_URL=http://localhost:3000`
+
+5. After saving the change, you should be login for the local environment
+
+---
+
 ## Local Development Setup
 
-To run the project locally for testing, configure your environment variables in:
+To connect front end to backend locally for testing, configure your environment variables in:
 
 `apps/app/.env.development`
 
-If the file does not exist, create it.
+The parameter update below is not needed if you completed the steps to login locally. If the file does not exist, create it.
 
 Add the following values:
-
-NEXT_PUBLIC_NAME=DEVELOPMENT\
-NEXT_PUBLIC_API_BASE_URL=http://localhost:1337\
-NEXT_PUBLIC_API_URL=http://localhost:1337/api\
-NEXT_PUBLIC_STRAPI_URL=http://localhost:1337/api\
-NEXT_PUBLIC_GOOGLE_AUTH_URL=http://localhost:1337/api/connect/google\
-NEXT_PUBLIC_DISCORD_AUTH_URL=https://discord.com/api/oauth2/authorize?client_id=815294711983112194&redirect_uri=https%3A%2F%2Fapi-staging.devlaunchers.org%2Fusers%2Fauth%2Fdiscord%2Fcallback&response_type=code&scope=identify\
-NEXT_PUBLIC_FRONT_END_URL=http://localhost:3000
+`NEXT_PUBLIC_NAME=DEVELOPMENT`  
+`NEXT_PUBLIC_API_BASE_URL=http://localhost:1337`  
+`NEXT_PUBLIC_API_URL=http://localhost:1337/api`  
+`NEXT_PUBLIC_STRAPI_URL=http://localhost:1337/api`  
+`NEXT_PUBLIC_GOOGLE_AUTH_URL=http://localhost:1337/api/connect/google`  
+`NEXT_PUBLIC_DISCORD_AUTH_URL=https://discord.com/api/oauth2/authorize?client_id=815294711983112194&redirect_uri=https%3A%2F%2Fapi-staging.devlaunchers.org%2Fusers%2Fauth%2Fdiscord%2Fcallback&response_type=code&scope=identify`  
+`NEXT_PUBLIC_FRONT_END_URL=http://localhost:3000 `
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To login to Devlauncher in local environment, please follow the steps below:
 
 1. Ensure you are log out for both staging and development Devlauncher website and keep both of these open in browser
 
-2. Change .env.devlopment file to match what it is in master branch as shown below:  
+2. Change .env.development file to match what it is in master branch as shown below:  
    `NEXT_PUBLIC_NAME=DEVELOPMENT`
    `NEXT_PUBLIC_API_BASE_URL=https://apiv4-staging.devlaunchers.org`  
    `NEXT_PUBLIC_API_URL=https://apiv4-staging.devlaunchers.org/api`  
@@ -86,7 +86,7 @@ Add the following values:
 `NEXT_PUBLIC_STRAPI_URL=http://localhost:1337/api`  
 `NEXT_PUBLIC_GOOGLE_AUTH_URL=http://localhost:1337/api/connect/google`  
 `NEXT_PUBLIC_DISCORD_AUTH_URL=https://discord.com/api/oauth2/authorize?client_id=815294711983112194&redirect_uri=https%3A%2F%2Fapi-staging.devlaunchers.org%2Fusers%2Fauth%2Fdiscord%2Fcallback&response_type=code&scope=identify`  
-`NEXT_PUBLIC_FRONT_END_URL=http://localhost:3000 `
+`NEXT_PUBLIC_FRONT_END_URL=http://localhost:3000`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -41,36 +41,6 @@ The release cadence is every 4 weeks. We will create a PR to merge the master br
 
 ---
 
-## Local Development Login
-
-To login to Devlauncher in local environment, please follow the steps below:
-
-1. Ensure you are log out for both staging and development Devlauncher website and keep both of these open in browser
-
-2. Change .env.development file to match what it is in master branch as shown below:  
-   `NEXT_PUBLIC_NAME=DEVELOPMENT`
-   `NEXT_PUBLIC_API_BASE_URL=https://apiv4-staging.devlaunchers.org`  
-   `NEXT_PUBLIC_API_URL=https://apiv4-staging.devlaunchers.org/api`  
-   `NEXT_PUBLIC_STRAPI_URL=https://apiv4-staging.devlaunchers.org/api`  
-   `NEXT_PUBLIC_GOOGLE_AUTH_URL=https://apiv4-staging.devlaunchers.org/api/connect/google`  
-   `NEXT_PUBLIC_DISCORD_AUTH_URL=https://discord.com/api/oauth2/authorize?client_id=815294711983112194&redirect_uri=https%3A%2F%2Fapi-staging.devlaunchers.org%2Fusers%2Fauth%2Fdiscord%2Fcallback&response_type=code&scope=identify`  
-   `NEXT_PUBLIC_FRONT_END_URL=http://localhost:3000`
-
-3. Login to your profile using staging Devlauncher website
-
-4. Once you are login, you can edit the .env.devlopment file to connect to your local api instead  
-   `NEXT_PUBLIC_NAME=DEVELOPMENT`  
-   `NEXT_PUBLIC_API_BASE_URL=http://localhost:1337`  
-   `NEXT_PUBLIC_API_URL=http://localhost:1337/api`  
-   `NEXT_PUBLIC_STRAPI_URL=http://localhost:1337/api`  
-   `NEXT_PUBLIC_GOOGLE_AUTH_URL=http://localhost:1337/api/connect/google`  
-   `NEXT_PUBLIC_DISCORD_AUTH_URL=https://discord.com/api/oauth2/authorize?client_id=815294711983112194&redirect_uri=https%3A%2F%2Fapi-staging.devlaunchers.org%2Fusers%2Fauth%2Fdiscord%2Fcallback&response_type=code&scope=identify`  
-   `NEXT_PUBLIC_FRONT_END_URL=http://localhost:3000`
-
-5. After saving the change, you should be login for the local environment
-
----
-
 ## Local Development Setup
 
 To connect front end to backend locally for testing, configure your environment variables in:

--- a/apps/ideaspace/src/components/common/IdeaForm/IdeaForm.js
+++ b/apps/ideaspace/src/components/common/IdeaForm/IdeaForm.js
@@ -231,7 +231,17 @@ const IdeaForm = ({
 
     try {
       const res = await agent.Ideas.findByName(name);
-      setNameTaken(res.length > 0);
+
+      const normalizedName = name.trim().toLowerCase();
+
+      const activeMatch = res.some((idea) => {
+        const sameName =
+          idea.attributes?.ideaName?.trim().toLowerCase() === normalizedName;
+        const notDeleted = idea.attributes?.status !== 'deleted';
+        return sameName && notDeleted;
+      });
+
+      setNameTaken(activeMatch);
     } catch (err) {
       console.error('Error checking idea name', err);
       setNameTaken(false);

--- a/apps/ideaspace/src/components/common/IdeaForm/IdeaForm.js
+++ b/apps/ideaspace/src/components/common/IdeaForm/IdeaForm.js
@@ -364,7 +364,7 @@ const IdeaForm = ({
                     {nameTaken && (
                       <ErrorText>
                         This idea name is already in use. Please try something
-                        else.
+                        else
                       </ErrorText>
                     )}
                     {!nameTaken &&

--- a/apps/ideaspace/src/components/common/IdeaForm/IdeaForm.js
+++ b/apps/ideaspace/src/components/common/IdeaForm/IdeaForm.js
@@ -230,9 +230,9 @@ const IdeaForm = ({
     }
 
     try {
-      const res = await agent.Ideas.findByName(name);
-
       const normalizedName = name.trim().toLowerCase();
+
+      const res = await agent.Ideas.findByName(normalizedName);
 
       const activeMatch = res.some((idea) => {
         const sameName =
@@ -364,7 +364,7 @@ const IdeaForm = ({
                     {nameTaken && (
                       <ErrorText>
                         This idea name is already in use. Please try something
-                        else
+                        else.
                       </ErrorText>
                     )}
                     {!nameTaken &&


### PR DESCRIPTION
I have successfully completed the bug fix for ISSUE https://github.com/dev-launchers/dev-launchers-platform/issues/2785.
Please also review backend PR https://github.com/dev-launchers/strapiv4/pull/323 related to this bug.

What's Included:

    Added Logic to check if taken idea_name is deleted
    Added documentation on how to update local environment and login to local environment

Files Affected:

    /ideaform.js
    /README.md

Technical Notes:

Previous name taken logic on front end does not check if the previous idea name was deleted already, I added the logic to account for this. I also added additional documentation on local development due to other new hire expressing similar question on how to setup. The implementation is complete and ready for staging deployment.
