### PR TITLE
feat #2748: (Frontend) IdeaSpace Comment Notifications 

### DIFF
--- a/apps/ideaspace/src/pages/_app.js
+++ b/apps/ideaspace/src/pages/_app.js
@@ -3,7 +3,7 @@ import { useRouter } from 'next/router';
 import { ThemeProvider } from 'styled-components';
 import GlobalStyle from '@devlaunchers/components/src/styles/global';
 import Head from 'next/head';
-
+import { toast, ToastContainer } from 'react-toastify';
 import IdeasBetaFeedbackModal from '../components/modules/IdeasBetaFeedbackModal';
 
 import 'react-toastify/dist/ReactToastify.css';
@@ -33,6 +33,7 @@ function MyApp(props) {
     <ThemeProvider theme={theme}>
       <Head><meta name="google-site-verification" content="KUjgcCuL0UXshh3A0F02itHW6KizSyra4BIsFE9Iz8I" /></Head>
       <GlobalStyle />
+      <ToastContainer />
       <IdeasBetaFeedbackModal />
       {props.children}
     </ThemeProvider>

--- a/packages/UI/package.json
+++ b/packages/UI/package.json
@@ -31,6 +31,7 @@
     "react-burger-menu": "^3.0.8",
     "react-dom": "^17.0.2",
     "react-scripts": "5.0.1",
+    "react-toastify": "9.1.3",
     "storybook-react-context": "^0.6.0",
     "styled-normalize": "^8.0.7",
     "tailwind-merge": "^1.13.2",

--- a/packages/UI/src/components/organisms/Navigation/NotificationPopover/NotificationPopover.tsx
+++ b/packages/UI/src/components/organisms/Navigation/NotificationPopover/NotificationPopover.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useRouter } from 'next/router';
 import {
   Popover,
   PopoverContent,
@@ -8,123 +9,113 @@ import { Bell, Settings } from 'lucide-react';
 import NotificationItem from '../../../molecules/NotificationItem/NotificationItem';
 import { agent } from '@devlaunchers/utility';
 import { Notification } from '@devlaunchers/models';
+import { useUserDataContext } from '../../../../context/UserDataContext';
+import useNotificationToast from '../../../../hooks/useNotificationToast';
 
 const SettingsIcon = Settings as React.FC<React.SVGProps<SVGSVGElement>>;
 const BellIcon = Bell as React.FC<React.SVGProps<SVGSVGElement>>;
 
 export default function NotificationPopover() {
+  const { isAuthenticated } = useUserDataContext();
   const [notifications, setNotifications] = React.useState<Notification[]>([]);
+  const router = useRouter();
+
+  useNotificationToast();
+
   const newNotificationsCount = notifications.reduce((count, x) => {
     return x.attributes.readDateTime ? count : count + 1;
   }, 0);
 
+  async function loadNotifications() {
+    try {
+      const data = await agent.Notifications.get();
+      if (!data || !Array.isArray(data)) return;
+      data.reverse();
+      setNotifications(data);
+    } catch (error) {
+      console.error('Notification fetch error:', error);
+    }
+  }
+
   React.useEffect(() => {
-    getAllNotifications();
-  }, []);
+    if (!isAuthenticated) return;
+    loadNotifications();
+  }, [isAuthenticated]);
 
-  function getAllNotifications() {
-    return agent.Notifications.get()
-      .then((data) => {
-        data.reverse();
-        setNotifications(data);
-      })
-      .catch((error) => {
-        console.log(error);
-      });
-  }
-
-  function markAllReadHandle() {
-    getAllNotifications();
-    setNotifications((prev) => {
-      return prev.map((n) => {
-        n.status = 'read';
-        return n;
-      });
-    });
-  }
+  React.useEffect(() => {
+    if (!isAuthenticated) return;
+    const handleRouteChange = () => loadNotifications();
+    router.events.on('routeChangeComplete', handleRouteChange);
+    return () => router.events.off('routeChangeComplete', handleRouteChange);
+  }, [isAuthenticated, router.events]);
 
   return (
-    <Popover>
-      <PopoverTrigger asChild>
-        <button
-          className="relative text-gray-300 hover:text-white transition-colors duration-200"
-          aria-label="notification"
-        >
-          {newNotificationsCount > 0 && (
-            <span className="absolute top-0 right-0 bg-[#52287A] text-white rounded-full w-5 h-5 text-xs flex items-center justify-center transform translate-x-1/2 -translate-y-1/2">
-              {newNotificationsCount}
-            </span>
-          )}
-          <BellIcon className="h-5 w-5" />
-        </button>
-      </PopoverTrigger>
-      <PopoverContent
-        className="w-[400px] p-0 border-0 mt-4"
-        hasCloseBtn={false}
-      >
-        <div className="bg-[#1C1C1C] text-white shadow-xl">
-          <div className="flex items-center justify-between p-4 border-b border-gray-800">
-            <span className="text-xl font-semibold text-white">
-              Notifications
-            </span>
-            {/* {notifications.length > 0 && (
-              <button
-                className="text-gray-300 hover:text-white transition-colors duration-200"
-                onClick={markAllReadHandle}
-              >
-                Mark all as read
-              </button>
-            )} */}
-          </div>
-
-          <div className="max-h-[400px] overflow-y-auto scrollbar-thin scrollbar-thumb-gray-600 scrollbar-track-gray-800">
-            {notifications.length > 0 ? (
-              notifications.map((n, i) => {
-                const { readDateTime, createdDateTime } = n.attributes;
-                const { action, entityName, eventUser, content, entityId } =
-                  n.attributes.event.data.attributes;
-                const { username, discord_avatar } = eventUser.data.attributes;
-                return (
-                  <NotificationItem
-                    key={i}
-                    action={action}
-                    target={entityName}
-                    avatar={discord_avatar}
-                    message={content}
-                    name={username}
-                    status={readDateTime ? 'read' : 'unRead'}
-                    targetLink={'/ideaspace/workshop/' + entityId}
-                    timeStamp={createdDateTime}
-                    className={`p-4 border-b border-gray-800 ${
-                      readDateTime ? 'bg-transparent' : 'bg-[#52287A]/10'
-                    } hover:bg-gray-800 transition-colors duration-200`}
-                  />
-                );
-              })
-            ) : (
-              <div className="flex flex-col items-center justify-center py-16 px-4">
-                <Bell
-                  className="h-16 w-16 text-gray-500 mb-4"
-                  strokeWidth={1.5}
-                />
-                <p className="text-gray-400 text-center">
-                  No notifications yet. We'll notify you when something
-                  important happens!
-                </p>
-              </div>
+    <>
+      <Popover>
+        <PopoverTrigger asChild>
+          <button
+            className="relative text-gray-300 hover:text-white transition-colors duration-200"
+            aria-label="notification"
+          >
+            {newNotificationsCount > 0 && (
+              <span className="absolute top-0 right-0 bg-[#52287A] text-white rounded-full w-5 h-5 text-xs flex items-center justify-center transform translate-x-1/2 -translate-y-1/2">
+                {newNotificationsCount}
+              </span>
             )}
+            <BellIcon className="h-5 w-5" />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent
+          className="w-[400px] p-0 border-0 mt-4"
+          hasCloseBtn={false}
+        >
+          <div className="bg-[#1C1C1C] text-white shadow-xl">
+            <div className="flex items-center justify-between p-4 border-b border-gray-800">
+              <span className="text-xl font-semibold text-white">
+                Notifications
+              </span>
+            </div>
+            <div className="max-h-[400px] overflow-y-auto scrollbar-thin scrollbar-thumb-gray-600 scrollbar-track-gray-800">
+              {notifications.length > 0 ? (
+                notifications.map((n, i) => {
+                  const { readDateTime, createdDateTime } = n.attributes;
+                  const { action, entityName, eventUser, content, entityId } =
+                    n.attributes.event.data.attributes;
+                  const { username, discord_avatar } =
+                    eventUser.data.attributes;
+                  return (
+                    <NotificationItem
+                      key={i}
+                      action={action}
+                      target={entityName}
+                      avatar={discord_avatar}
+                      message={content}
+                      name={username}
+                      status={readDateTime ? 'read' : 'unRead'}
+                      targetLink={'/ideaspace/workshop/' + entityId}
+                      timeStamp={createdDateTime}
+                      className={`p-4 border-b border-gray-800 ${
+                        readDateTime ? 'bg-transparent' : 'bg-[#52287A]/10'
+                      } hover:bg-gray-800 transition-colors duration-200`}
+                    />
+                  );
+                })
+              ) : (
+                <div className="flex flex-col items-center justify-center py-16 px-4">
+                  <Bell
+                    className="h-16 w-16 text-gray-500 mb-4"
+                    strokeWidth={1.5}
+                  />
+                  <p className="text-gray-400 text-center">
+                    No notifications yet. We'll notify you when something
+                    important happens!
+                  </p>
+                </div>
+              )}
+            </div>
           </div>
-
-          {/* <div className="flex items-center justify-center p-4 border-t border-gray-800">
-            <a
-              href="/notifications"
-              className="text-gray-300 hover:text-white transition-colors duration-200"
-            >
-              View all notifications
-            </a>
-          </div> */}
-        </div>
-      </PopoverContent>
-    </Popover>
+        </PopoverContent>
+      </Popover>
+    </>
   );
 }

--- a/packages/UI/src/hooks/useNotificationToast.ts
+++ b/packages/UI/src/hooks/useNotificationToast.ts
@@ -1,0 +1,87 @@
+import { useEffect } from 'react';
+import { toast } from 'react-toastify';
+import { useRouter } from 'next/router';
+import * as React from 'react';
+import { useUserDataContext } from '../context/UserDataContext';
+import { agent } from '@devlaunchers/utility';
+import Alert from '../components/molecules/Alert';
+
+// Module-level — shared across ALL instances of this hook
+const seenIds = new Set<number>();
+let isFirstFetch = true;
+let isFetching = false;
+let hasMounted = false;
+
+function showToast(entityName: string, entityId: number, notificationId: number) {
+  toast(
+    React.createElement(Alert, { signal: 'notify' }, `New comment on "${entityName}"`),
+    {
+      toastId: notificationId,
+      position: 'top-right',
+      autoClose: 5000,
+      hideProgressBar: true,
+      closeOnClick: true,
+      pauseOnHover: true,
+      style: { background: 'transparent', boxShadow: 'none', padding: 0 },
+      onClick: () => {
+        window.location.href = `/ideaspace/workshop/${entityId}`;
+      },
+    }
+  );
+}
+
+export default function useNotificationToast() {
+  const { isAuthenticated } = useUserDataContext();
+  const router = useRouter();
+
+  async function fetchNotifications() {
+    if (isFetching) return;
+    isFetching = true;
+
+    try {
+      const data = await agent.Notifications.get();
+      if (!data || !Array.isArray(data)) return;
+
+      if (isFirstFetch) {
+        isFirstFetch = false;
+        data.forEach((n) => {
+          seenIds.add(n.id);
+          const { readDateTime, event } = n.attributes;
+          if (readDateTime) return;
+          const { action, entityName, entityId } = event.data.attributes;
+          if (action !== 'Commented') return;
+          showToast(entityName, entityId, n.id);
+        });
+        return;
+      }
+
+      data.forEach((n) => {
+        if (seenIds.has(n.id)) return;
+        seenIds.add(n.id);
+        const { readDateTime, event } = n.attributes;
+        if (readDateTime) return;
+        const { action, entityName, entityId } = event.data.attributes;
+        if (action !== 'Commented') return;
+        showToast(entityName, entityId, n.id);
+      });
+    } catch (error) {
+      console.error('Notification fetch error:', error);
+    } finally {
+      isFetching = false;
+    }
+  }
+
+  useEffect(() => {
+    if (!isAuthenticated) return;
+    if (hasMounted) return;
+    hasMounted = true;
+    fetchNotifications();
+  }, [isAuthenticated]);
+
+  useEffect(() => {
+    if (!isAuthenticated) return;
+    const handleRouteChange = () => fetchNotifications();
+    router.events.on('routeChangeComplete', handleRouteChange);
+    return () => router.events.off('routeChangeComplete', handleRouteChange);
+  }, [isAuthenticated, router.events]);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2784,6 +2784,7 @@ __metadata:
     react-burger-menu: ^3.0.8
     react-dom: ^17.0.2
     react-scripts: 5.0.1
+    react-toastify: 9.1.3
     rimraf: 3.0.2
     shell-quote: 1.7.3
     storybook: 7.2.2
@@ -35835,7 +35836,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-toastify@npm:^9.0.7":
+"react-toastify@npm:9.1.3, react-toastify@npm:^9.0.7":
   version: 9.1.3
   resolution: "react-toastify@npm:9.1.3"
   dependencies:


### PR DESCRIPTION
## NOTE
[Mark Notifications as Read](https://github.com/dev-launchers/dev-launchers-platform/issues/2832) should be implemented alongside this feature. Otherwise these toasts will get noisy very quickly

### Background

This PR is 2 of 2 PR's. This implements frontend changes for [#2748](https://github.com/dev-launchers/dev-launchers-platform/issues/2748). This should be merged **AFTER** the [Backend PR](https://github.com/dev-launchers/strapiv4/compare/2748-toastNotifications?expand=1).

### Summary
Implements frontend toast notifications for comment activity on ideas. When a user logs in or navigates between pages, unread comment notifications are fetched and displayed as toast alerts in the top right corner of the screen.

### Changes
`packages/UI/src/hooks/useNotificationToast.ts (new file)
`
* Custom hook that fetches unread comment notifications and displays them as toasts
* On first fetch (login/page load) — toasts any unread Commented notifications missed while offline
* On subsequent fetches (page navigation) — toasts any new unseen unread Commented notifications
* Uses module-level state (seenIds, isFetching, hasMounted) to prevent duplicate toasts across multiple NotificationPopover instances mounted in the navbar (desktop + mobile)
* Only triggers for action === "Commented" notifications — idea created/updated events are ignored

`packages/UI/src/components/organisms/Navigation/NotificationPopover/NotificationPopover.tsx`
* Integrated useNotificationToast hook
* Removed inline toast logic, replaced with hook call
* Bell dropdown UI unchanged

`apps/ideaspace/src/pages/_app.js
`
* Added react-toastify@9.1.3 dependency
* Note: all other apps in the monorepo already depend on ^9.0.7 so there are no version conflicts. Can be moved to apps/ideaspace/package.json if preferred.

### Testing
* Tested locally with two accounts — one as idea owner, one as commenter. Verified toast appears for idea owner on login and page navigation. Verified commenter does not receive a toast for their own comment.

<img width="373" height="606" alt="image" src="https://github.com/user-attachments/assets/af3693c3-189e-40f8-ae22-1f0619934653" />
