### PR TITLE
fix(navigation): removed the debugging statement from navigation

### DIFF
--- a/apps/ideaspace/src/components/modules/WorkshoppingPage/CommentsForm/SingleComment.js
+++ b/apps/ideaspace/src/components/modules/WorkshoppingPage/CommentsForm/SingleComment.js
@@ -11,6 +11,7 @@ import { useUserDataContext } from '@devlaunchers/components/src/context/UserDat
 import { atoms } from '@devlaunchers/components/src/components';
 import { agent } from '@devlaunchers/utility';
 import UpvoteButton from '../../../../components/common/Upvote/UpvoteButton';
+import DefaultPic from '../../../../images/profile-picture-upload.png';
 // A function to show the date as X hours ago, etc.
 // from: https://stackoverflow.com/a/3177838
 function timeSince(date) {
@@ -116,7 +117,7 @@ function SingleCommentComponent(props) {
         <SingleComment style={{ marginBottom: '12px' }}>
           <UserImage
             alt="user_image"
-            src={props.user.profile?.profilePictureUrl}
+            src={props.user.profile?.profilePictureUrl || DefaultPic}
           />
           <div className="textContent">
             <SingleCommentContent>

--- a/packages/UI/src/components/organisms/Navigation/Navigation.tsx
+++ b/packages/UI/src/components/organisms/Navigation/Navigation.tsx
@@ -189,9 +189,6 @@ const ProfileDropdown = ({ userData }: { userData: UserData }) => {
                 src={userData?.profilePictureUrl || prof_default}
                 alt="Profile"
                 className={styles.profileImage}
-                onLoad={(e) => {
-                  console.log('Loaded:', e.currentTarget.src);
-                }}
               />
               <span>{userData?.name}</span>
             </div>


### PR DESCRIPTION
remove debugging line from navigation.
added or statement to use default comment for historical comment

This is followup from pull request 2835 to remove the debugging statement. I also added the logic for historical comment that was missed.

Before
<img width="391" height="559" alt="image" src="https://github.com/user-attachments/assets/4bcce2fd-08dc-400b-aab6-7ae35965077a" />


After
<img width="1256" height="339" alt="image" src="https://github.com/user-attachments/assets/90f97068-4a65-413b-8e04-f38506057813" />
