### PR TITLE
fix(termsconditionlayout): update terms and condition page to be in l…

### DIFF
--- a/apps/ideaspace/src/components/modules/TermsConditionPage/TermsConditionLayout.js
+++ b/apps/ideaspace/src/components/modules/TermsConditionPage/TermsConditionLayout.js
@@ -7,359 +7,395 @@ import { atoms } from '@devlaunchers/components/components';
 const TermsConditionLayout = () => {
   return (
     <>
-      <div className="max-w-8xl px-[20px] sm:px-[24px] md:px-[32px] lg:px-[48px] py-10">
-        {/* <BackButton buttonType="confirm"/> */}
-        <div className="flex flex-col gap-[10px] mb-8">
-          <atoms.Typography
-            as="h2"
-            variant="primary"
-            size="xl4"
-            textWeight="light"
-          >
-            {TermsConditionContent.introduction.heading}
-          </atoms.Typography>
-          <div>
-            {TermsConditionContent.introduction.paragraphs.map(
-              (para, index) => (
-                <atoms.Typography
-                  key={index}
-                  as="p"
-                  variant="secondary"
-                  size="body_base"
-                >
-                  {para}
-                </atoms.Typography>
-              )
-            )}
-          </div>
-        </div>
-
-        <div className="flex flex-col gap-[6px] mb-8">
-          <atoms.Typography
-            as="h3"
-            variant="primary"
-            size="xl2"
-            textWeight="light"
-          >
-            {TermsConditionContent.definitions.heading}
-          </atoms.Typography>
-          <ul className="ml-3 list-disc pl-5">
-            {TermsConditionContent.definitions.paragraphs.map((para, index) => (
-              <li key={index}>
-                <atoms.Typography
-                  as="span"
-                  variant="secondary"
-                  size="body_base"
-                >
-                  {para.map((part, i) =>
-                    part.bold ? (
-                      <span className="font-medium" key={i}>
-                        {part.text}
-                      </span>
-                    ) : (
-                      <span key={i}>{part.text}</span>
-                    )
-                  )}
-                </atoms.Typography>
-              </li>
-            ))}
-          </ul>
-        </div>
-
-        <div className="flex flex-col gap-[6px] mb-8">
-          <atoms.Typography
-            as="h3"
-            variant="primary"
-            size="xl2"
-            textWeight="light"
-          >
-            Summary
-          </atoms.Typography>
-          <atoms.Typography as="p" variant="secondary" size="body_base">
-            You understand and agree to be bound to the following terms and
-            conditions when you submit your idea, use and collaborate in Dev
-            Launchers website.
-          </atoms.Typography>
-        </div>
-
-        <TermsTable />
-
-        <div className="flex flex-col gap-[10px] mb-8">
-          <atoms.Typography
-            as="h2"
-            variant="primary"
-            size="xl4"
-            textWeight="light"
-            id="age-eligibility"
-          >
-            {TermsConditionContent.ageEligibility.heading}
-          </atoms.Typography>
-          <div className="flex flex-col">
-            {TermsConditionContent.ageEligibility.paragraphs.map(
-              (para, index) => (
-                <atoms.Typography
-                  key={index}
-                  as="p"
-                  variant="secondary"
-                  size="body_base"
-                >
-                  {para}
-                </atoms.Typography>
-              )
-            )}
-          </div>
-        </div>
-
-        <div className="flex flex-col gap-[10px] mb-8">
-          <atoms.Typography
-            as="h2"
-            variant="primary"
-            size="xl4"
-            textWeight="light"
-            id="non-confidentiality"
-          >
-            {TermsConditionContent.nonCondidentiality.heading}
-          </atoms.Typography>
-          <div className="flex flex-col">
-            {TermsConditionContent.nonCondidentiality.paragraphs.map(
-              (para, index) => (
-                <atoms.Typography
-                  key={index}
-                  as="p"
-                  variant="secondary"
-                  size="body_base"
-                >
-                  {para}
-                </atoms.Typography>
-              )
-            )}
-          </div>
-        </div>
-
-        <div className="flex flex-col gap-[10px] mb-8">
-          <atoms.Typography
-            as="h2"
-            variant="primary"
-            size="xl4"
-            textWeight="light"
-            id="user-generated"
-          >
-            {TermsConditionContent.userGenerated.heading}
-          </atoms.Typography>
-
-          <div className="flex flex-col gap-[10px]">
-            {Object.entries(TermsConditionContent.userGenerated).map(
-              ([key, section], index) =>
-                key !== 'heading' && (
-                  <div key={index} className={key}>
-                    <atoms.Typography
-                      as="h3"
-                      variant="primary"
-                      size="xl2"
-                      textWeight="light"
-                      className="mb-[6px]"
-                    >
-                      {section.heading}
-                    </atoms.Typography>
-                    <ul className="ml-3 list-disc pl-5">
-                      {section.pointers.map((pointer, i) => (
-                        <li key={i}>
-                          <atoms.Typography
-                            as="span"
-                            variant="secondary"
-                            size="body_base"
-                          >
-                            {pointer}
-                          </atoms.Typography>
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                )
-            )}
-          </div>
-        </div>
-
-        <div className="flex flex-col gap-[10px] mb-8">
-          <atoms.Typography
-            as="h2"
-            variant="primary"
-            size="xl4"
-            textWeight="light"
-            id="i-property-rights"
-          >
-            {TermsConditionContent.intellectualPropertyRights.heading}
-          </atoms.Typography>
-          <div className="flex flex-col">
-            {TermsConditionContent.intellectualPropertyRights.paragraphs.map(
-              (para, index) => (
-                <atoms.Typography
-                  key={index}
-                  as="p"
-                  variant="secondary"
-                  size="body_base"
-                >
-                  {para}
-                </atoms.Typography>
-              )
-            )}
-          </div>
-        </div>
-
-        <div className="flex flex-col mb-8">
-          <atoms.Typography
-            as="h2"
-            variant="primary"
-            size="xl4"
-            textWeight="light"
-            id="idea-evaluation"
-            className="mb-[10px]"
-          >
-            {TermsConditionContent.ideaEvaluation.heading}
-          </atoms.Typography>
-          <ul className="mb-[10px]">
-            {TermsConditionContent.ideaEvaluation.paragraphs.map(
-              (para, index) => (
-                <li key={index} className="ml-8 list-disc">
+      <div className="w-full bg-black text-white min-h-screen">
+        <div className="max-w-8xl mx-auto px-[20px] sm:px-[24px] md:px-[32px] lg:px-[48px] pt-2 pb-10">
+          {/* <BackButton buttonType="confirm"/> */}
+          <div className="flex flex-col gap-[10px] mb-8">
+            <atoms.Typography
+              as="h2"
+              variant="primary"
+              size="xl4"
+              textWeight="light"
+              className="text-white"
+            >
+              {TermsConditionContent.introduction.heading}
+            </atoms.Typography>
+            <div>
+              {TermsConditionContent.introduction.paragraphs.map(
+                (para, index) => (
                   <atoms.Typography
-                    as="span"
+                    key={index}
+                    as="p"
                     variant="secondary"
                     size="body_base"
+                    className="text-gray-300"
                   >
                     {para}
                   </atoms.Typography>
-                </li>
-              )
-            )}
-          </ul>
-          <div className="selectionProcess mb-[10px]">
-            <atoms.Typography
-              as="h3"
-              variant="primary"
-              size="xl2"
-              textWeight="light"
-              className="mb-[6px]"
-            >
-              Selection Process:
-            </atoms.Typography>
-            <atoms.Typography as="p" variant="secondary" size="body_base">
-              {TermsConditionContent.ideaEvaluation.selectionProcess}
-            </atoms.Typography>
+                )
+              )}
+            </div>
           </div>
 
-          <div className="Examples">
+          <div className="flex flex-col gap-[6px] mb-8">
             <atoms.Typography
               as="h3"
               variant="primary"
               size="xl2"
               textWeight="light"
-              className="mb-[6px]"
+              className="text-white"
             >
-              Examples of Ideas and suggestions that Dev Launchers will not be
-              considered are:
+              {TermsConditionContent.definitions.heading}
             </atoms.Typography>
             <ul className="ml-3 list-disc pl-5">
-              {TermsConditionContent.ideaEvaluation.subPointers.map(
-                (pointer, index) => (
+              {TermsConditionContent.definitions.paragraphs.map(
+                (para, index) => (
                   <li key={index}>
                     <atoms.Typography
                       as="span"
                       variant="secondary"
                       size="body_base"
+                      className="text-gray-300"
                     >
-                      {pointer}
+                      {para.map((part, i) =>
+                        part.bold ? (
+                          <span className="font-medium" key={i}>
+                            {part.text}
+                          </span>
+                        ) : (
+                          <span key={i}>{part.text}</span>
+                        )
+                      )}
                     </atoms.Typography>
                   </li>
                 )
               )}
             </ul>
           </div>
-        </div>
 
-        <div className="flex flex-col gap-[10px] mb-8">
-          <atoms.Typography
-            as="h2"
-            variant="primary"
-            size="xl4"
-            textWeight="light"
-            id="consulting"
-          >
-            {TermsConditionContent.consulting.heading}
-          </atoms.Typography>
-          {TermsConditionContent.consulting.paragraphs.map((para, index) => (
+          <div className="flex flex-col gap-[6px] mb-8">
             <atoms.Typography
-              key={index}
+              as="h3"
+              variant="primary"
+              size="xl2"
+              textWeight="light"
+              className="text-white"
+            >
+              Summary
+            </atoms.Typography>
+            <atoms.Typography
               as="p"
               variant="secondary"
               size="body_base"
+              className="text-gray-300"
             >
-              {para}
+              You understand and agree to be bound to the following terms and
+              conditions when you submit your idea, use and collaborate in Dev
+              Launchers website.
             </atoms.Typography>
-          ))}
-        </div>
+          </div>
 
-        <div className="flex flex-col gap-[10px] mb-8">
-          <atoms.Typography
-            as="h2"
-            variant="primary"
-            size="xl4"
-            textWeight="light"
-            id="indemnity"
-          >
-            {TermsConditionContent.indemnity.heading}
-          </atoms.Typography>
-          <div>
-            {TermsConditionContent.indemnity.paragraphs.map((para, index) => (
+          <TermsTable />
+
+          <div className="flex flex-col gap-[10px] mb-8">
+            <atoms.Typography
+              as="h2"
+              variant="primary"
+              size="xl4"
+              textWeight="light"
+              className="text-white"
+              id="age-eligibility"
+            >
+              {TermsConditionContent.ageEligibility.heading}
+            </atoms.Typography>
+            <div className="flex flex-col">
+              {TermsConditionContent.ageEligibility.paragraphs.map(
+                (para, index) => (
+                  <atoms.Typography
+                    key={index}
+                    as="p"
+                    variant="secondary"
+                    size="body_base"
+                    className="text-gray-300"
+                  >
+                    {para}
+                  </atoms.Typography>
+                )
+              )}
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-[10px] mb-8">
+            <atoms.Typography
+              as="h2"
+              variant="primary"
+              size="xl4"
+              textWeight="light"
+              className="text-white"
+              id="non-confidentiality"
+            >
+              {TermsConditionContent.nonCondidentiality.heading}
+            </atoms.Typography>
+            <div className="flex flex-col">
+              {TermsConditionContent.nonCondidentiality.paragraphs.map(
+                (para, index) => (
+                  <atoms.Typography
+                    key={index}
+                    as="p"
+                    variant="secondary"
+                    size="body_base"
+                    className="text-gray-300"
+                  >
+                    {para}
+                  </atoms.Typography>
+                )
+              )}
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-[10px] mb-8">
+            <atoms.Typography
+              as="h2"
+              variant="primary"
+              size="xl4"
+              textWeight="light"
+              className="text-white"
+              id="user-generated"
+            >
+              {TermsConditionContent.userGenerated.heading}
+            </atoms.Typography>
+
+            <div className="flex flex-col gap-[10px]">
+              {Object.entries(TermsConditionContent.userGenerated).map(
+                ([key, section], index) =>
+                  key !== 'heading' && (
+                    <div key={index} className={key}>
+                      <atoms.Typography
+                        as="h3"
+                        variant="primary"
+                        size="xl2"
+                        textWeight="light"
+                        className="mb-[6px] text-white"
+                      >
+                        {section.heading}
+                      </atoms.Typography>
+                      <ul className="ml-3 list-disc pl-5">
+                        {section.pointers.map((pointer, i) => (
+                          <li key={i}>
+                            <atoms.Typography
+                              as="span"
+                              variant="secondary"
+                              size="body_base"
+                              className="text-gray-300"
+                            >
+                              {pointer}
+                            </atoms.Typography>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )
+              )}
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-[10px] mb-8">
+            <atoms.Typography
+              as="h2"
+              variant="primary"
+              size="xl4"
+              textWeight="light"
+              className="text-white"
+              id="i-property-rights"
+            >
+              {TermsConditionContent.intellectualPropertyRights.heading}
+            </atoms.Typography>
+            <div className="flex flex-col">
+              {TermsConditionContent.intellectualPropertyRights.paragraphs.map(
+                (para, index) => (
+                  <atoms.Typography
+                    key={index}
+                    as="p"
+                    variant="secondary"
+                    size="body_base"
+                    className="text-gray-300"
+                  >
+                    {para}
+                  </atoms.Typography>
+                )
+              )}
+            </div>
+          </div>
+
+          <div className="flex flex-col mb-8">
+            <atoms.Typography
+              as="h2"
+              variant="primary"
+              size="xl4"
+              textWeight="light"
+              id="idea-evaluation"
+              className="mb-[10px] text-white"
+            >
+              {TermsConditionContent.ideaEvaluation.heading}
+            </atoms.Typography>
+            <ul className="mb-[10px]">
+              {TermsConditionContent.ideaEvaluation.paragraphs.map(
+                (para, index) => (
+                  <li key={index} className="ml-8 list-disc">
+                    <atoms.Typography
+                      as="span"
+                      variant="secondary"
+                      size="body_base"
+                      className="text-gray-300"
+                    >
+                      {para}
+                    </atoms.Typography>
+                  </li>
+                )
+              )}
+            </ul>
+            <div className="selectionProcess mb-[10px]">
+              <atoms.Typography
+                as="h3"
+                variant="primary"
+                size="xl2"
+                textWeight="light"
+                className="mb-[6px] text-white"
+              >
+                Selection Process:
+              </atoms.Typography>
+              <atoms.Typography
+                as="p"
+                variant="secondary"
+                size="body_base"
+                className="text-gray-300"
+              >
+                {TermsConditionContent.ideaEvaluation.selectionProcess}
+              </atoms.Typography>
+            </div>
+
+            <div className="Examples">
+              <atoms.Typography
+                as="h3"
+                variant="primary"
+                size="xl2"
+                textWeight="light"
+                className="mb-[6px] text-white"
+              >
+                Examples of Ideas and suggestions that Dev Launchers will not be
+                considered are:
+              </atoms.Typography>
+              <ul className="ml-3 list-disc pl-5">
+                {TermsConditionContent.ideaEvaluation.subPointers.map(
+                  (pointer, index) => (
+                    <li key={index}>
+                      <atoms.Typography
+                        as="span"
+                        variant="secondary"
+                        size="body_base"
+                        className="text-gray-300"
+                      >
+                        {pointer}
+                      </atoms.Typography>
+                    </li>
+                  )
+                )}
+              </ul>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-[10px] mb-8">
+            <atoms.Typography
+              as="h2"
+              variant="primary"
+              size="xl4"
+              textWeight="light"
+              id="consulting"
+              className="text-white"
+            >
+              {TermsConditionContent.consulting.heading}
+            </atoms.Typography>
+            {TermsConditionContent.consulting.paragraphs.map((para, index) => (
               <atoms.Typography
                 key={index}
                 as="p"
                 variant="secondary"
                 size="body_base"
+                className="text-gray-300"
               >
                 {para}
               </atoms.Typography>
             ))}
-            <ul className="ml-3 list-disc pl-5">
-              {TermsConditionContent.indemnity.subPointers.map(
-                (pointer, index) => (
-                  <li key={index}>
-                    <atoms.Typography
-                      as="span"
-                      variant="secondary"
-                      size="body_base"
-                    >
-                      {pointer}
-                    </atoms.Typography>
-                  </li>
-                )
-              )}
-            </ul>
           </div>
-        </div>
 
-        <div className="flex flex-col gap-[10px] mb-[140px]">
-          <atoms.Typography
-            as="h2"
-            variant="primary"
-            size="xl4"
-            textWeight="light"
-            id="changeToTerms"
-          >
-            {TermsConditionContent.changeToTerms.heading}
-          </atoms.Typography>
-          <div className="flex flex-col gap-1">
-            {TermsConditionContent.changeToTerms.paragraphs.map(
-              (para, index) => (
+          <div className="flex flex-col gap-[10px] mb-8">
+            <atoms.Typography
+              as="h2"
+              variant="primary"
+              size="xl4"
+              textWeight="light"
+              id="indemnity"
+              className="text-white"
+            >
+              {TermsConditionContent.indemnity.heading}
+            </atoms.Typography>
+            <div>
+              {TermsConditionContent.indemnity.paragraphs.map((para, index) => (
                 <atoms.Typography
                   key={index}
                   as="p"
                   variant="secondary"
                   size="body_base"
+                  className="text-gray-300"
                 >
                   {para}
                 </atoms.Typography>
-              )
-            )}
+              ))}
+              <ul className="ml-3 list-disc pl-5">
+                {TermsConditionContent.indemnity.subPointers.map(
+                  (pointer, index) => (
+                    <li key={index}>
+                      <atoms.Typography
+                        as="span"
+                        variant="secondary"
+                        size="body_base"
+                        className="text-gray-300"
+                      >
+                        {pointer}
+                      </atoms.Typography>
+                    </li>
+                  )
+                )}
+              </ul>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-[10px] mb-8">
+            <atoms.Typography
+              as="h2"
+              variant="primary"
+              size="xl4"
+              textWeight="light"
+              id="changeToTerms"
+              className="text-white"
+            >
+              {TermsConditionContent.changeToTerms.heading}
+            </atoms.Typography>
+            <div className="flex flex-col gap-1">
+              {TermsConditionContent.changeToTerms.paragraphs.map(
+                (para, index) => (
+                  <atoms.Typography
+                    key={index}
+                    as="p"
+                    variant="secondary"
+                    size="body_base"
+                    className="text-gray-300"
+                  >
+                    {para}
+                  </atoms.Typography>
+                )
+              )}
+            </div>
           </div>
         </div>
       </div>

--- a/apps/ideaspace/src/components/modules/TermsConditionPage/TermsConditionPage.js
+++ b/apps/ideaspace/src/components/modules/TermsConditionPage/TermsConditionPage.js
@@ -14,9 +14,7 @@ function TermsConditionPage() {
           variant="primary"
           size="xl5"
           textWeight="bold"
-        >
-          IdeaSpace
-        </atoms.Typography>
+        ></atoms.Typography>
         <div className="hidden sm:block">
           <BackButton
             buttonType="confirm"
@@ -28,16 +26,17 @@ function TermsConditionPage() {
           variant="primary"
           size="xl4"
           textWeight="bold"
+          className="pl-8"
         >
           Idea Submission Terms & Conditions
         </atoms.Typography>
 
-        <StyledRainbow>
-          <div className="h-1 w-full bg-gradient-to-r from-[#FF0000] via-[#00FF00] to-[#0000FF]" />
-        </StyledRainbow>
-
         <div className="HeadingSub flex flex-col gap-3">
-          <atoms.Typography variant="secondary" size="body_base">
+          <atoms.Typography
+            variant="secondary"
+            size="body_base"
+            className="pl-8"
+          >
             Last updated: April 26, 2023
           </atoms.Typography>
         </div>

--- a/apps/ideaspace/src/components/modules/TermsConditionPage/TermsTable.js
+++ b/apps/ideaspace/src/components/modules/TermsConditionPage/TermsTable.js
@@ -6,7 +6,7 @@ const TermsTable = () => {
     <>
       <div className="relative overflow-x-auto shadow-md rounded-xl mb-8">
         <table className="w-full text-sm text-left rtl:text-right text-gray-500 hidden sm:table">
-          <thead className="text-gray-700 uppercase bg-[#F0EDEE]">
+          <thead className="text-white uppercase bg-[#1E2530]">
             <tr>
               <th scope="col" className="px-6 py-3">
                 <atoms.Typography
@@ -31,9 +31,9 @@ const TermsTable = () => {
             </tr>
           </thead>
           <tbody>
-            <tr className="bg-white border-b">
+            <tr className="bg-gray-800 border-b">
               <th scope="row" className="px-6 py-4 whitespace-nowrap">
-                <a href="#age-eligibility" className="text-[#3A7CA5] underline">
+                <a href="#age-eligibility" className="text-sky-400 underline">
                   <atoms.Typography
                     as="span"
                     variant="primary"
@@ -44,21 +44,22 @@ const TermsTable = () => {
                   </atoms.Typography>
                 </a>
               </th>
-              <td className="px-6 py-4">
+              <td className="px-6 py-4 ">
                 <atoms.Typography
                   as="span"
                   variant="secondary"
                   size="body_base"
+                  className="text-sky-400"
                 >
                   How old do you have to be to use our platform?
                 </atoms.Typography>
               </td>
             </tr>
-            <tr className="bg-white border-b">
+            <tr className="bg-gray-800 border-b">
               <th scope="row" className="px-6 py-4 whitespace-nowrap">
                 <a
                   href="#non-confidentiality"
-                  className="text-[#3A7CA5] underline"
+                  className="text-sky-400 underline"
                 >
                   <atoms.Typography
                     as="span"
@@ -81,9 +82,9 @@ const TermsTable = () => {
                 </atoms.Typography>
               </td>
             </tr>
-            <tr className="bg-white">
+            <tr className="bg-gray-800 border-b">
               <th scope="row" className="px-6 py-4 whitespace-nowrap">
-                <a href="#user-generated" className="text-[#3A7CA5] underline">
+                <a href="#user-generated" className="text-sky-400 underline">
                   <atoms.Typography
                     as="span"
                     variant="primary"
@@ -107,12 +108,9 @@ const TermsTable = () => {
               </td>
             </tr>
 
-            <tr className="bg-white border-b">
+            <tr className="bg-gray-800 border-b">
               <th scope="row" className="px-6 py-4 whitespace-nowrap">
-                <a
-                  href="#i-property-rights"
-                  className="text-[#3A7CA5] underline"
-                >
+                <a href="#i-property-rights" className="text-sky-400 underline">
                   <atoms.Typography
                     as="span"
                     variant="primary"
@@ -135,9 +133,9 @@ const TermsTable = () => {
               </td>
             </tr>
 
-            <tr className="bg-white border-b">
+            <tr className="bg-gray-800 border-b">
               <th scope="row" className="px-6 py-4 whitespace-nowrap">
-                <a href="#idea-evaluation" className="text-[#3A7CA5] underline">
+                <a href="#idea-evaluation" className="text-sky-400 underline">
                   <atoms.Typography
                     as="span"
                     variant="primary"
@@ -161,9 +159,9 @@ const TermsTable = () => {
               </td>
             </tr>
 
-            <tr className="bg-white border-b">
+            <tr className="bg-gray-800 border-b">
               <th scope="row" className="px-6 py-4 whitespace-nowrap">
-                <a href="#indemnity" className="text-[#3A7CA5] underline">
+                <a href="#indemnity" className="text-sky-400 underline">
                   <atoms.Typography
                     as="span"
                     variant="primary"
@@ -188,9 +186,9 @@ const TermsTable = () => {
               </td>
             </tr>
 
-            <tr className="bg-white border-b">
+            <tr className="bg-gray-800 border-b">
               <th scope="row" className="px-6 py-4 whitespace-nowrap">
-                <a href="#changeToTerms" className="text-[#3A7CA5] underline">
+                <a href="#changeToTerms" className="text-sky-400 underline">
                   <atoms.Typography
                     as="span"
                     variant="primary"
@@ -233,7 +231,7 @@ const TermsTable = () => {
           <tbody>
             <tr className="bg-white border-b flex flex-col">
               <th scope="row" className="px-6 py-4 whitespace-nowrap">
-                <a href="#age-eligibility" className="text-[#3A7CA5] underline">
+                <a href="#age-eligibility" className="text-sky-400 underline">
                   <atoms.Typography
                     as="span"
                     variant="primary"
@@ -258,7 +256,7 @@ const TermsTable = () => {
               <th scope="row" className="px-6 py-4 whitespace-nowrap">
                 <a
                   href="#non-confidentiality"
-                  className="text-[#3A7CA5] underline"
+                  className="text-sky-400 underline"
                 >
                   <atoms.Typography
                     as="span"
@@ -283,7 +281,7 @@ const TermsTable = () => {
             </tr>
             <tr className="bg-white border-b flex flex-col">
               <th scope="row" className="px-6 py-4 whitespace-nowrap">
-                <a href="#user-generated" className="text-[#3A7CA5] underline">
+                <a href="#user-generated" className="text-sky-400 underline">
                   <atoms.Typography
                     as="span"
                     variant="primary"
@@ -309,10 +307,7 @@ const TermsTable = () => {
 
             <tr className="bg-white border-b flex flex-col">
               <th scope="row" className="px-6 py-4 whitespace-nowrap">
-                <a
-                  href="#i-property-rights"
-                  className="text-[#3A7CA5] underline"
-                >
+                <a href="#i-property-rights" className="text-sky-400 underline">
                   <atoms.Typography
                     as="span"
                     variant="primary"
@@ -337,7 +332,7 @@ const TermsTable = () => {
 
             <tr className="bg-white border-b flex flex-col">
               <th scope="row" className="px-6 py-4 whitespace-nowrap">
-                <a href="#idea-evaluation" className="text-[#3A7CA5] underline">
+                <a href="#idea-evaluation" className="text-sky-400 underline">
                   <atoms.Typography
                     as="span"
                     variant="primary"
@@ -363,7 +358,7 @@ const TermsTable = () => {
 
             <tr className="bg-white border-b flex flex-col">
               <th scope="row" className="px-6 py-4 whitespace-nowrap">
-                <a href="#indemnity" className="text-[#3A7CA5] underline">
+                <a href="#indemnity" className="text-sky-400 underline">
                   <atoms.Typography
                     as="span"
                     variant="primary"
@@ -390,7 +385,7 @@ const TermsTable = () => {
 
             <tr className="bg-white border-b flex flex-col">
               <th scope="row" className="px-6 py-4 whitespace-nowrap">
-                <a href="#changeToTerms" className="text-[#3A7CA5] underline">
+                <a href="#changeToTerms" className="text-sky-400 underline">
                   <atoms.Typography
                     as="span"
                     variant="primary"


### PR DESCRIPTION
Update terms and condition to use dark mode color

Remove divider and add in better contrast color

Ticket # 2830

Before: 

<img width="2483" height="846" alt="image" src="https://github.com/user-attachments/assets/5cd1128f-ee9f-4157-86ea-f1f05436a1cd" />
<img width="2420" height="848" alt="image" src="https://github.com/user-attachments/assets/10a3b8fa-0dc8-4e17-80d4-4db7b453d3a7" />
<img width="2356" height="863" alt="image" src="https://github.com/user-attachments/assets/8b24e3ca-1e25-4978-acfb-3a486a07677e" />


After:
<img width="2415" height="953" alt="image" src="https://github.com/user-attachments/assets/442f608f-e185-4c1f-9327-41568e83bb4b" />
<img width="2418" height="846" alt="image" src="https://github.com/user-attachments/assets/6dec1377-4893-4bef-adf2-e73038b63c49" />
<img width="2446" height="680" alt="image" src="https://github.com/user-attachments/assets/27aac089-efe7-4552-ab04-58c133d052a8" />
